### PR TITLE
implement SLA analytics dashboard

### DIFF
--- a/src/components/dashboard/KPICard.tsx
+++ b/src/components/dashboard/KPICard.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+interface KPICardProps {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  highlight?: "green" | "red" | "blue" | "yellow";
+}
+
+const highlightMap: Record<string, string> = {
+  green: "border-green-500 bg-green-50",
+  red: "border-red-500 bg-red-50",
+  blue: "border-blue-500 bg-blue-50",
+  yellow: "border-yellow-500 bg-yellow-50",
+};
+
+const valueColorMap: Record<string, string> = {
+  green: "text-green-700",
+  red: "text-red-700",
+  blue: "text-blue-700",
+  yellow: "text-yellow-700",
+};
+
+const KPICard: React.FC<KPICardProps> = ({
+  title,
+  value,
+  subtitle,
+  highlight = "blue",
+}) => {
+  return (
+    <div
+      className={`rounded-xl border-l-4 p-5 shadow-sm ${highlightMap[highlight]}`}
+    >
+      <p className="text-sm font-medium text-gray-500">{title}</p>
+      <p className={`mt-1 text-3xl font-bold ${valueColorMap[highlight]}`}>
+        {value}
+      </p>
+      {subtitle && <p className="mt-1 text-xs text-gray-400">{subtitle}</p>}
+    </div>
+  );
+};
+
+export default KPICard;

--- a/src/components/dashboard/PenaltiesRewardsChart.tsx
+++ b/src/components/dashboard/PenaltiesRewardsChart.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { TrendPoint } from "../../types/dashboard";
+
+interface PenaltiesRewardsChartProps {
+  data: TrendPoint[];
+}
+
+const formatCurrency = (value: number) =>
+  `$${value.toLocaleString()}`;
+
+const PenaltiesRewardsChart: React.FC<PenaltiesRewardsChartProps> = ({
+  data,
+}) => {
+  return (
+    <div className="rounded-xl bg-white p-5 shadow-sm">
+      <h3 className="mb-4 text-sm font-semibold text-gray-600 uppercase tracking-wide">
+        Penalties vs Rewards Over Time
+      </h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <BarChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="period" tick={{ fontSize: 12 }} />
+          <YAxis tickFormatter={formatCurrency} tick={{ fontSize: 12 }} />
+          <Tooltip formatter={(value: number) => formatCurrency(value)} />
+          <Legend />
+          <Bar dataKey="penalties" name="Penalties" fill="#ef4444" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="rewards" name="Rewards" fill="#22c55e" radius={[4, 4, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default PenaltiesRewardsChart;

--- a/src/components/dashboard/SLATrendChart.tsx
+++ b/src/components/dashboard/SLATrendChart.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { TrendPoint } from "../../types/dashboard";
+
+interface SLATrendChartProps {
+  data: TrendPoint[];
+}
+
+const SLATrendChart: React.FC<SLATrendChartProps> = ({ data }) => {
+  return (
+    <div className="rounded-xl bg-white p-5 shadow-sm">
+      <h3 className="mb-4 text-sm font-semibold text-gray-600 uppercase tracking-wide">
+        SLA Compliance Trend
+      </h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="period" tick={{ fontSize: 12 }} />
+          <YAxis
+            domain={[0, 100]}
+            tickFormatter={(v) => `${v}%`}
+            tick={{ fontSize: 12 }}
+          />
+          <Tooltip formatter={(value: number) => [`${value}%`, "Compliance"]} />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="compliance_percentage"
+            name="Compliance %"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            dot={{ r: 4 }}
+            activeDot={{ r: 6 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default SLATrendChart;

--- a/src/pages/SLADashboard.tsx
+++ b/src/pages/SLADashboard.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { fetchDashboardMetrics } from "../services/dashboardService";
+import { DashboardMetrics } from "../types/dashboard";
+import KPICard from "../components/dashboard/KPICard";
+import SLATrendChart from "../components/dashboard/SLATrendChart";
+import PenaltiesRewardsChart from "../components/dashboard/PenaltiesRewardsChart";
+
+const SLADashboard: React.FC = () => {
+  const [metrics, setMetrics] = useState<DashboardMetrics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchDashboardMetrics()
+      .then(setMetrics)
+      .catch(() => setError("Failed to load dashboard metrics."))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center text-gray-500">
+        Loading dashboard...
+      </div>
+    );
+  }
+
+  if (error || !metrics) {
+    return (
+      <div className="flex h-64 items-center justify-center text-red-500">
+        {error || "No data available."}
+      </div>
+    );
+  }
+
+  const netBalance = metrics.rewards.total - metrics.penalties.total;
+
+  return (
+    <div className="space-y-6 p-6">
+      <h1 className="text-2xl font-bold text-gray-800">SLA Analytics Dashboard</h1>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <KPICard
+          title="SLA Compliance"
+          value={`${metrics.sla_compliance_percentage.toFixed(1)}%`}
+          subtitle="Overall compliance rate"
+          highlight={metrics.sla_compliance_percentage >= 90 ? "green" : "red"}
+        />
+        <KPICard
+          title="Total Penalties"
+          value={`$${metrics.penalties.total.toLocaleString()}`}
+          subtitle={`${metrics.penalties.count} incidents`}
+          highlight="red"
+        />
+        <KPICard
+          title="Total Rewards"
+          value={`$${metrics.rewards.total.toLocaleString()}`}
+          subtitle={`${metrics.rewards.count} achievements`}
+          highlight="green"
+        />
+        <KPICard
+          title="Net Balance"
+          value={`${netBalance >= 0 ? "+" : ""}$${netBalance.toLocaleString()}`}
+          subtitle="Rewards minus penalties"
+          highlight={netBalance >= 0 ? "green" : "red"}
+        />
+      </div>
+
+      {/* Charts */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <SLATrendChart data={metrics.trends} />
+        <PenaltiesRewardsChart data={metrics.trends} />
+      </div>
+    </div>
+  );
+};
+
+export default SLADashboard;

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+import { DashboardMetrics } from "../types/dashboard";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
+
+export const fetchDashboardMetrics = async (): Promise<DashboardMetrics> => {
+  const response = await axios.get<DashboardMetrics>(
+    `${API_BASE}/dashboard/metrics`
+  );
+  return response.data;
+};

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,19 @@
+export interface TrendPoint {
+  period: string;
+  compliance_percentage: number;
+  penalties: number;
+  rewards: number;
+}
+
+export interface DashboardMetrics {
+  sla_compliance_percentage: number;
+  penalties: {
+    total: number;
+    count: number;
+  };
+  rewards: {
+    total: number;
+    count: number;
+  };
+  trends: TrendPoint[];
+}


### PR DESCRIPTION
Description:
  Adds a real-time SLA analytics dashboard powered by GET /dashboard/metrics.

  Changes:
  - KPI cards for SLA compliance %, total penalties, total rewards, and net balance
  - Line chart showing SLA compliance trend over time
  - Bar chart comparing penalties vs rewards per period
  - Dashboard service, types, and reusable components
  
  closes #31 