### PR TITLE
feat: filter presets, payment drawer, auth nav, SLA disputes (#86 #88…

### DIFF
--- a/src/app/outages/[id]/page.tsx
+++ b/src/app/outages/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 
 import { ResolveOutageModal } from "@/features/outages/components/ResolveOutageModal";
+import { SLADisputesPanel } from "@/components/outages/SLADisputesPanel";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
@@ -290,6 +291,8 @@ export default function OutageDetailsPage() {
             </div>
           </CardContent>
         </Card>
+
+        <SLADisputesPanel outageId={outage.id} canResolve={isResolved} />
       </div>
 
       <ResolveOutageModal

--- a/src/app/outages/components/outages-page-client.tsx
+++ b/src/app/outages/components/outages-page-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 
 import { DataTable } from "@/components/data-table";
@@ -8,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { useOutages } from "@/features/outages/hooks/useOutages";
-import { useOutagesTableState } from "@/hooks/useOutagesTableState";
+import { useFilterPresets, useOutagesTableState } from "@/hooks/useOutagesTableState";
 import type { Outage } from "@/types/outages";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -61,9 +62,11 @@ const columns: ColumnDef<Outage>[] = [
 
 export function OutagesPageClient() {
     const { state, actions } = useOutagesTableState();
+    const { presets, savePreset, deletePreset } = useFilterPresets();
     const { data, isLoading, isError } = useOutages(state);
     const totalItems = data?.total ?? 0;
     const totalPages = Math.max(1, Math.ceil(totalItems / state.page_size));
+    const [presetName, setPresetName] = useState("");
 
     if (isLoading) {
         return (
@@ -103,6 +106,50 @@ export function OutagesPageClient() {
                         status: state.status,
                     }}
                 />
+            </div>
+
+            {/* Filter presets */}
+            <div className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+                <span className="text-xs font-medium text-slate-500 uppercase tracking-wide">Presets:</span>
+                {presets.map((preset) => (
+                    <div key={preset.name} className="flex items-center gap-1">
+                        <button
+                            className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100"
+                            onClick={() => {
+                                actions.setSeverity(preset.severity);
+                                actions.setStatus(preset.status);
+                            }}
+                        >
+                            {preset.name}
+                        </button>
+                        <button
+                            className="text-slate-400 hover:text-red-500 text-xs"
+                            onClick={() => deletePreset(preset.name)}
+                            aria-label={`Delete preset ${preset.name}`}
+                        >
+                            ×
+                        </button>
+                    </div>
+                ))}
+                <div className="ml-auto flex items-center gap-2">
+                    <input
+                        className="rounded-md border border-slate-200 px-2 py-1 text-xs"
+                        placeholder="Preset name"
+                        value={presetName}
+                        onChange={(e) => setPresetName(e.target.value)}
+                    />
+                    <Button
+                        variant="outline"
+                        className="text-xs h-7 px-2"
+                        disabled={!presetName.trim()}
+                        onClick={() => {
+                            savePreset({ name: presetName.trim(), severity: state.severity, status: state.status });
+                            setPresetName("");
+                        }}
+                    >
+                        Save preset
+                    </Button>
+                </div>
             </div>
 
             <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,12 +1,45 @@
+"use client";
+
 import Link from "next/link";
+import { useSession } from "@/hooks/useSession";
 
 const Navigation = () => {
+  const { state, user, logout } = useSession();
+
   return (
-    <nav style={{ padding: "1rem", borderBottom: "1px solid #ccc" }}>
-      <Link href="/">Dashboard</Link> | <Link href="/outages">Outages</Link> |{" "}
-      <Link href="/bulk-import">Bulk Import</Link> |{" "}
-      <Link href="/payments">Payments</Link> |{" "}
-      <Link href="/setting">Wallet &amp; Settings</Link>
+    <nav style={{ padding: "1rem", borderBottom: "1px solid #ccc" }} className="flex items-center justify-between">
+      <div className="flex gap-3">
+        <Link href="/">Dashboard</Link> |{" "}
+        <Link href="/outages">Outages</Link> |{" "}
+        <Link href="/bulk-import">Bulk Import</Link> |{" "}
+        <Link href="/payments">Payments</Link> |{" "}
+        <Link href="/setting">Wallet &amp; Settings</Link>
+      </div>
+
+      <div className="text-sm text-slate-600">
+        {state === "loading" && (
+          <span className="text-slate-400">Checking session…</span>
+        )}
+        {state === "authenticated" && user && (
+          <span className="flex items-center gap-3">
+            <span>{user.email}</span>
+            <button
+              onClick={() => void logout()}
+              className="rounded border border-slate-200 px-2 py-0.5 text-xs hover:bg-slate-100"
+            >
+              Sign out
+            </button>
+          </span>
+        )}
+        {state === "unauthenticated" && (
+          <Link
+            href="/login"
+            className="rounded border border-slate-200 px-2 py-0.5 text-xs hover:bg-slate-100"
+          >
+            Sign in
+          </Link>
+        )}
+      </div>
     </nav>
   );
 };

--- a/src/components/outages/SLADisputesPanel.tsx
+++ b/src/components/outages/SLADisputesPanel.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { flagDispute, getDisputes, resolveDispute } from "@/services/sla";
+import type { SLADispute } from "@/types/sla";
+
+const statusVariant: Record<string, "outline" | "secondary" | "destructive" | "default"> = {
+  open: "destructive",
+  under_review: "secondary",
+  resolved: "default",
+  rejected: "outline",
+};
+
+interface Props {
+  outageId: string;
+  canResolve?: boolean;
+}
+
+export function SLADisputesPanel({ outageId, canResolve = false }: Props) {
+  const [disputes, setDisputes] = useState<SLADispute[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reason, setReason] = useState("");
+  const [flagging, setFlagging] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    getDisputes(outageId)
+      .then((data) => { if (isMounted) setDisputes(data); })
+      .catch(() => { if (isMounted) setError("Failed to load disputes."); })
+      .finally(() => { if (isMounted) setLoading(false); });
+    return () => { isMounted = false; };
+  }, [outageId]);
+
+  async function handleFlag() {
+    if (!reason.trim()) return;
+    setFlagging(true);
+    setError(null);
+    try {
+      const dispute = await flagDispute(outageId, reason.trim());
+      setDisputes((prev) => [dispute, ...prev]);
+      setReason("");
+    } catch {
+      setError("Failed to flag dispute.");
+    } finally {
+      setFlagging(false);
+    }
+  }
+
+  async function handleAction(disputeId: string, action: "resolve" | "reject") {
+    setResolvingId(disputeId);
+    setError(null);
+    try {
+      const updated = await resolveDispute(disputeId, action);
+      setDisputes((prev) => prev.map((d) => (d.id === disputeId ? updated : d)));
+    } catch {
+      setError(`Failed to ${action} dispute.`);
+    } finally {
+      setResolvingId(null);
+    }
+  }
+
+  return (
+    <Card className="md:col-span-2">
+      <CardHeader className="pb-3">
+        <CardTitle>SLA Disputes</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        {/* Flag new dispute */}
+        <div className="flex gap-2">
+          <input
+            className="flex-1 rounded-md border border-slate-200 px-3 py-2 text-sm"
+            placeholder="Reason for dispute…"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            disabled={flagging}
+          />
+          <Button
+            variant="outline"
+            disabled={!reason.trim() || flagging}
+            onClick={() => void handleFlag()}
+          >
+            {flagging ? "Flagging…" : "Flag dispute"}
+          </Button>
+        </div>
+
+        {error && (
+          <p className="text-xs text-red-600">{error}</p>
+        )}
+
+        {loading && <p className="text-slate-400 italic">Loading disputes…</p>}
+
+        {!loading && disputes.length === 0 && (
+          <p className="italic text-slate-400">No disputes filed for this outage.</p>
+        )}
+
+        {disputes.map((dispute, i) => (
+          <div key={dispute.id}>
+            {i > 0 && <Separator className="my-3" />}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Badge variant={statusVariant[dispute.status] ?? "outline"} className="capitalize">
+                  {dispute.status.replace("_", " ")}
+                </Badge>
+                <span className="text-xs text-slate-400">
+                  {new Date(dispute.created_at).toLocaleString()}
+                </span>
+              </div>
+              <p className="text-slate-700">{dispute.reason}</p>
+              {dispute.resolution_note && (
+                <p className="text-xs text-slate-500 italic">Note: {dispute.resolution_note}</p>
+              )}
+              {canResolve && dispute.status === "open" && (
+                <div className="flex gap-2 pt-1">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={resolvingId === dispute.id}
+                    onClick={() => void handleAction(dispute.id, "resolve")}
+                  >
+                    Resolve
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={resolvingId === dispute.id}
+                    onClick={() => void handleAction(dispute.id, "reject")}
+                  >
+                    Reject
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/payments/payment-detail-drawer.tsx
+++ b/src/components/payments/payment-detail-drawer.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
+import { fetchPayment } from "@/services/paymentService";
+import type { Payment } from "@/types/payment";
+
+const statusStyles: Record<string, string> = {
+  completed: "bg-green-100 text-green-700",
+  pending: "bg-yellow-100 text-yellow-700",
+  failed: "bg-red-100 text-red-700",
+  confirmed: "bg-emerald-100 text-emerald-700",
+};
+
+interface Props {
+  paymentId: string | null;
+  onClose: () => void;
+}
+
+export function PaymentDetailDrawer({ paymentId, onClose }: Props) {
+  const [payment, setPayment] = useState<Payment | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!paymentId) {
+      setPayment(null);
+      return;
+    }
+    let isMounted = true;
+    setLoading(true);
+    setError(null);
+    fetchPayment(paymentId)
+      .then((data) => { if (isMounted) setPayment(data); })
+      .catch(() => { if (isMounted) setError("Failed to load payment details."); })
+      .finally(() => { if (isMounted) setLoading(false); });
+    return () => { isMounted = false; };
+  }, [paymentId]);
+
+  if (!paymentId) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/30"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Drawer */}
+      <aside className="fixed right-0 top-0 z-50 flex h-full w-full max-w-md flex-col bg-white shadow-xl">
+        <div className="flex items-center justify-between border-b px-6 py-4">
+          <h2 className="text-lg font-semibold text-slate-900">Payment Details</h2>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 text-xl leading-none"
+            aria-label="Close drawer"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          {loading && (
+            <RouteLoadingState
+              title="Loading payment"
+              description="Fetching transaction metadata."
+            />
+          )}
+          {error && (
+            <RouteErrorState
+              title="Error"
+              description={error}
+              actionLabel="Retry"
+              onAction={() => {
+                setError(null);
+                setLoading(true);
+                fetchPayment(paymentId!)
+                  .then(setPayment)
+                  .catch(() => setError("Failed to load payment details."))
+                  .finally(() => setLoading(false));
+              }}
+            />
+          )}
+          {!loading && !error && payment && (
+            <dl className="space-y-4 text-sm">
+              <Row label="Payment ID" value={payment.id} mono />
+              <Row label="Outage ID" value={payment.outage_id} mono />
+              <Row
+                label="Type"
+                value={
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${payment.type === "penalty" ? "bg-red-100 text-red-700" : "bg-blue-100 text-blue-700"}`}>
+                    {payment.type}
+                  </span>
+                }
+              />
+              <Row
+                label="Amount"
+                value={
+                  <span className={`font-semibold ${payment.type === "penalty" ? "text-red-600" : "text-green-600"}`}>
+                    {payment.type === "penalty" ? "-" : "+"}${payment.amount.toLocaleString()} {payment.asset_code}
+                  </span>
+                }
+              />
+              <Row
+                label="Status"
+                value={
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${statusStyles[payment.status] ?? "bg-gray-100 text-gray-500"}`}>
+                    {payment.status}
+                  </span>
+                }
+              />
+              <Row label="From" value={payment.from_address} mono />
+              <Row label="To" value={payment.to_address} mono />
+              <Row label="Transaction Hash" value={payment.transaction_hash} mono />
+              <Row label="Created" value={new Date(payment.created_at).toLocaleString()} />
+              {payment.confirmed_at && (
+                <Row label="Confirmed" value={new Date(payment.confirmed_at).toLocaleString()} />
+              )}
+            </dl>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}
+
+function Row({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
+  return (
+    <div className="flex flex-col gap-1 border-b border-slate-100 pb-3">
+      <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+      <dd className={`break-all text-slate-900 ${mono ? "font-mono text-xs" : ""}`}>{value}</dd>
+    </div>
+  );
+}

--- a/src/components/payments/payments-view.tsx
+++ b/src/components/payments/payments-view.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 
+import { PaymentDetailDrawer } from "@/components/payments/payment-detail-drawer";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { fetchPayments } from "@/services/paymentService";
 import type { PaginatedPayments, Payment } from "@/types/payment";
@@ -25,6 +26,7 @@ export default function PaymentsView() {
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedPaymentId, setSelectedPaymentId] = useState<string | null>(null);
   const requestKey = useMemo(() => `${page}:${PER_PAGE}`, [page]);
 
   useEffect(() => {
@@ -111,7 +113,11 @@ export default function PaymentsView() {
     }
 
     return data.items.map((payment: Payment) => (
-      <tr key={payment.id} className="border-t transition-colors hover:bg-gray-50">
+      <tr
+        key={payment.id}
+        className="border-t transition-colors hover:bg-gray-50 cursor-pointer"
+        onClick={() => setSelectedPaymentId(payment.id)}
+      >
         <td className="px-4 py-3 text-sm font-mono text-gray-700">{payment.outage_id}</td>
         <td className="px-4 py-3">
           <span
@@ -148,7 +154,6 @@ export default function PaymentsView() {
   return (
     <div className="space-y-4 p-6">
       <h1 className="text-2xl font-bold text-gray-800">Payments</h1>
-
       <div className="overflow-hidden rounded-xl bg-white shadow-sm">
         <table className="w-full text-left">
           <thead className="bg-gray-50">
@@ -190,6 +195,11 @@ export default function PaymentsView() {
           </div>
         </div>
       ) : null}
+
+      <PaymentDetailDrawer
+        paymentId={selectedPaymentId}
+        onClose={() => setSelectedPaymentId(null)}
+      />
     </div>
   );
 }

--- a/src/hooks/useOutagesTableState.ts
+++ b/src/hooks/useOutagesTableState.ts
@@ -10,6 +10,42 @@ function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Failed to load outages";
 }
 
+const PRESETS_KEY = "outage_filter_presets";
+
+export interface FilterPreset {
+  name: string;
+  severity?: string;
+  status?: string;
+}
+
+export function useFilterPresets() {
+  const [presets, setPresets] = useState<FilterPreset[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(PRESETS_KEY) ?? "[]") as FilterPreset[];
+    } catch {
+      return [];
+    }
+  });
+
+  function savePreset(preset: FilterPreset) {
+    setPresets((prev) => {
+      const next = [...prev.filter((p) => p.name !== preset.name), preset];
+      localStorage.setItem(PRESETS_KEY, JSON.stringify(next));
+      return next;
+    });
+  }
+
+  function deletePreset(name: string) {
+    setPresets((prev) => {
+      const next = prev.filter((p) => p.name !== name);
+      localStorage.setItem(PRESETS_KEY, JSON.stringify(next));
+      return next;
+    });
+  }
+
+  return { presets, savePreset, deletePreset };
+}
+
 // Existing state manager
 export function useOutagesTableState() {
   const params = useSearchParams();

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+export type SessionState = "loading" | "authenticated" | "unauthenticated";
+
+interface SessionUser {
+  id: string;
+  email: string;
+}
+
+export function useSession() {
+  const [state, setState] = useState<SessionState>("loading");
+  const [user, setUser] = useState<SessionUser | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    api
+      .get<SessionUser>("/auth/me")
+      .then((res) => {
+        if (isMounted) {
+          setUser(res.data);
+          setState("authenticated");
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setUser(null);
+          setState("unauthenticated");
+        }
+      });
+    return () => { isMounted = false; };
+  }, []);
+
+  async function logout() {
+    try {
+      await api.post("/auth/logout");
+    } finally {
+      setUser(null);
+      setState("unauthenticated");
+    }
+  }
+
+  return { state, user, logout };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,7 @@ export const api = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
+  withCredentials: true,
 });
 
 // Optional: basic response/error interceptor

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -1,5 +1,5 @@
 import { api } from "@/lib/api";
-import { PaginatedPayments } from "../types/payment";
+import { PaginatedPayments, Payment } from "../types/payment";
 
 export const fetchPayments = async (
   page: number = 1,
@@ -8,5 +8,10 @@ export const fetchPayments = async (
   const response = await api.get<PaginatedPayments>("/payments", {
     params: { page, page_size: perPage },
   });
+  return response.data;
+};
+
+export const fetchPayment = async (id: string): Promise<Payment> => {
+  const response = await api.get<Payment>(`/payments/${id}`);
   return response.data;
 };

--- a/src/services/sla.ts
+++ b/src/services/sla.ts
@@ -1,5 +1,5 @@
 import { api } from "@/lib/api";
-import type { SLAResult } from "@/types/sla";
+import type { SLAResult, SLADispute } from "@/types/sla";
 
 export async function calculateSLA(params: {
   outage_id: string;
@@ -17,5 +17,20 @@ export async function previewSLA(params: {
   mttr_minutes: number;
 }): Promise<SLAResult> {
   const res = await api.post<SLAResult>("/sla/preview", params);
+  return res.data;
+}
+
+export async function getDisputes(outageId: string): Promise<SLADispute[]> {
+  const res = await api.get<SLADispute[]>(`/sla/disputes`, { params: { outage_id: outageId } });
+  return res.data;
+}
+
+export async function flagDispute(outageId: string, reason: string): Promise<SLADispute> {
+  const res = await api.post<SLADispute>(`/sla/disputes`, { outage_id: outageId, reason });
+  return res.data;
+}
+
+export async function resolveDispute(disputeId: string, action: "resolve" | "reject", note?: string): Promise<SLADispute> {
+  const res = await api.patch<SLADispute>(`/sla/disputes/${disputeId}`, { action, resolution_note: note });
   return res.data;
 }

--- a/src/types/sla.ts
+++ b/src/types/sla.ts
@@ -7,3 +7,16 @@ export interface SLAResult {
   payment_type: "reward" | "penalty";
   rating: "exceptional" | "excellent" | "good" | "poor";
 }
+
+export type DisputeStatus = "open" | "under_review" | "resolved" | "rejected";
+
+export interface SLADispute {
+  id: string;
+  outage_id: string;
+  sla_result_id?: string;
+  status: DisputeStatus;
+  reason: string;
+  created_at: string;
+  resolved_at?: string | null;
+  resolution_note?: string | null;
+}


### PR DESCRIPTION
… #90 #91)

- [FE-019] Add saved outage filter presets with localStorage persistence
  - useFilterPresets hook in useOutagesTableState.ts
  - Save/apply/delete preset UI in outages-page-client.tsx

- [FE-021] Add payment detail drawer from payments table
  - PaymentDetailDrawer component with full transaction metadata
  - fetchPayment service function
  - Clickable rows in payments-view.tsx

- [FE-023] Add auth-aware navigation and session state handling
  - useSession hook calling /auth/me
  - Navigation shows signed-in user, sign-out, or sign-in link
  - api.ts adds withCredentials for cookie-based sessions

- [FE-024] Add disputes UI for SLA results
  - SLADispute type in types/sla.ts
  - getDisputes/flagDispute/resolveDispute in services/sla.ts
  - SLADisputesPanel component on outage detail page

Closes #86 , closes #88 , closes #90 , closes #91 