### PR TITLE
feat: add login, register, webhooks, and bulk import history screens

### DIFF
--- a/src/app/bulk-import/history/page.tsx
+++ b/src/app/bulk-import/history/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { fetchBulkImportHistory } from "@/services/bulkImportService";
+import type { BulkImportRecord } from "@/types/bulkImport";
+
+export default function BulkImportHistoryPage() {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const { data: records = [], isLoading, isError } = useQuery({
+    queryKey: ["bulk-import-history"],
+    queryFn: fetchBulkImportHistory,
+  });
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-800">Import History</h1>
+          <p className="text-sm text-gray-500">Previous bulk import attempts and their outcomes.</p>
+        </div>
+        <Link
+          href="/bulk-import"
+          className="rounded-lg border px-4 py-2 text-sm text-gray-600 hover:bg-gray-50"
+        >
+          ← New import
+        </Link>
+      </div>
+
+      {isLoading && <p className="text-sm text-gray-400">Loading history…</p>}
+      {isError && (
+        <p className="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-600">
+          Failed to load import history.
+        </p>
+      )}
+
+      {!isLoading && !isError && records.length === 0 && (
+        <p className="text-sm text-gray-400">No import history yet.</p>
+      )}
+
+      <div className="space-y-3">
+        {records.map((record: BulkImportRecord) => (
+          <div key={record.id} className="rounded-xl border bg-white shadow-sm">
+            <div className="flex items-center justify-between p-4">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-gray-800">{record.filename}</p>
+                <p className="mt-0.5 text-xs text-gray-400">
+                  {new Date(record.created_at).toLocaleString()}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-4">
+                <div className="flex gap-3 text-xs">
+                  <span className="text-green-600 font-medium">{record.imported} imported</span>
+                  <span className="text-yellow-600 font-medium">{record.skipped} skipped</span>
+                  {record.error_count > 0 && (
+                    <span className="text-red-600 font-medium">{record.error_count} errors</span>
+                  )}
+                </div>
+                {record.error_count > 0 && (
+                  <button
+                    onClick={() => setExpanded(expanded === record.id ? null : record.id)}
+                    className="rounded border px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                  >
+                    {expanded === record.id ? "Hide errors" : "View errors"}
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {expanded === record.id && record.errors.length > 0 && (
+              <div className="border-t px-4 pb-4 pt-3">
+                <ul className="max-h-48 space-y-1 overflow-y-auto rounded-lg bg-red-50 p-3">
+                  {record.errors.map((err, i) => (
+                    <li key={i} className="text-xs text-red-700">
+                      {err.row != null && <span className="font-semibold">Row {err.row}: </span>}
+                      {err.field && <span className="font-semibold">[{err.field}] </span>}
+                      {err.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { api } from "@/lib/api";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      await api.post("/auth/login", { email, password });
+      router.push("/");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Login failed. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-sm space-y-6 p-8 pt-16">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold text-gray-800">Sign in</h1>
+        <p className="text-sm text-gray-500">Enter your credentials to continue.</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-1">
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            required
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        {error && (
+          <p className="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-600">{error}</p>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded-lg bg-blue-600 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {loading ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+
+      <p className="text-center text-sm text-gray-500">
+        No account?{" "}
+        <Link href="/register" className="text-blue-600 hover:underline">
+          Register
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { api } from "@/lib/api";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await api.post("/auth/register", { email, password });
+      // Auto-login after registration
+      await api.post("/auth/login", { email, password });
+      router.push("/");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Registration failed. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-sm space-y-6 p-8 pt-16">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold text-gray-800">Create account</h1>
+        <p className="text-sm text-gray-500">Register to access the NOC IQ platform.</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-1">
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            required
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="confirm" className="block text-sm font-medium text-gray-700">
+            Confirm password
+          </label>
+          <input
+            id="confirm"
+            type="password"
+            required
+            autoComplete="new-password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        {error && (
+          <p className="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-600">{error}</p>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded-lg bg-blue-600 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {loading ? "Creating account…" : "Create account"}
+        </button>
+      </form>
+
+      <p className="text-center text-sm text-gray-500">
+        Already have an account?{" "}
+        <Link href="/login" className="text-blue-600 hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/webhooks/page.tsx
+++ b/src/app/webhooks/page.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchWebhooks,
+  createWebhook,
+  updateWebhook,
+  deleteWebhook,
+  fetchWebhookDeliveries,
+  retryDelivery,
+} from "@/services/webhookService";
+import type { Webhook, WebhookDelivery } from "@/types/webhook";
+
+const AVAILABLE_EVENTS = ["outage.created", "outage.resolved", "payment.processed", "sla.breached"];
+
+export default function WebhooksPage() {
+  const qc = useQueryClient();
+  const [selectedWebhook, setSelectedWebhook] = useState<Webhook | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [formUrl, setFormUrl] = useState("");
+  const [formEvents, setFormEvents] = useState<string[]>([]);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const { data: webhooks = [], isLoading } = useQuery({
+    queryKey: ["webhooks"],
+    queryFn: fetchWebhooks,
+  });
+
+  const { data: deliveries = [], isLoading: deliveriesLoading } = useQuery({
+    queryKey: ["webhook-deliveries", selectedWebhook?.id],
+    queryFn: () => fetchWebhookDeliveries(selectedWebhook!.id),
+    enabled: !!selectedWebhook,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createWebhook,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["webhooks"] });
+      resetForm();
+    },
+    onError: (err: Error) => setFormError(err.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: Parameters<typeof updateWebhook>[1] }) =>
+      updateWebhook(id, payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["webhooks"] });
+      resetForm();
+    },
+    onError: (err: Error) => setFormError(err.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteWebhook,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["webhooks"] });
+      if (selectedWebhook) setSelectedWebhook(null);
+    },
+  });
+
+  const retryMutation = useMutation({
+    mutationFn: ({ webhookId, deliveryId }: { webhookId: string; deliveryId: string }) =>
+      retryDelivery(webhookId, deliveryId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["webhook-deliveries", selectedWebhook?.id] }),
+  });
+
+  function resetForm() {
+    setShowForm(false);
+    setFormUrl("");
+    setFormEvents([]);
+    setFormError(null);
+    setEditingId(null);
+  }
+
+  function openCreate() {
+    setEditingId(null);
+    setFormUrl("");
+    setFormEvents([]);
+    setFormError(null);
+    setShowForm(true);
+  }
+
+  function openEdit(wh: Webhook) {
+    setEditingId(wh.id);
+    setFormUrl(wh.url);
+    setFormEvents(wh.events);
+    setFormError(null);
+    setShowForm(true);
+  }
+
+  function toggleEvent(event: string) {
+    setFormEvents((prev) =>
+      prev.includes(event) ? prev.filter((e) => e !== event) : [...prev, event]
+    );
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    if (!formUrl) { setFormError("URL is required."); return; }
+    if (formEvents.length === 0) { setFormError("Select at least one event."); return; }
+
+    if (editingId) {
+      updateMutation.mutate({ id: editingId, payload: { url: formUrl, events: formEvents } });
+    } else {
+      createMutation.mutate({ url: formUrl, events: formEvents });
+    }
+  }
+
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-800">Webhooks</h1>
+          <p className="text-sm text-gray-500">Manage webhook endpoints and delivery history.</p>
+        </div>
+        <button
+          onClick={openCreate}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+        >
+          + New webhook
+        </button>
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4 rounded-xl border bg-white p-5 shadow-sm"
+        >
+          <h2 className="text-base font-semibold text-gray-700">
+            {editingId ? "Edit webhook" : "New webhook"}
+          </h2>
+
+          <div className="space-y-1">
+            <label className="block text-sm font-medium text-gray-700">Payload URL</label>
+            <input
+              type="url"
+              required
+              value={formUrl}
+              onChange={(e) => setFormUrl(e.target.value)}
+              placeholder="https://example.com/webhook"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-gray-700">Events</p>
+            <div className="flex flex-wrap gap-2">
+              {AVAILABLE_EVENTS.map((ev) => (
+                <label key={ev} className="flex cursor-pointer items-center gap-1.5 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={formEvents.includes(ev)}
+                    onChange={() => toggleEvent(ev)}
+                    className="rounded"
+                  />
+                  {ev}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {formError && (
+            <p className="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-600">{formError}</p>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-40"
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </button>
+            <button
+              type="button"
+              onClick={resetForm}
+              className="rounded-lg border px-4 py-2 text-sm text-gray-600 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm text-gray-400">Loading webhooks…</p>
+      ) : webhooks.length === 0 ? (
+        <p className="text-sm text-gray-400">No webhooks configured yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {webhooks.map((wh) => (
+            <div
+              key={wh.id}
+              className="rounded-xl border bg-white p-4 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-gray-800">{wh.url}</p>
+                  <p className="mt-0.5 text-xs text-gray-400">
+                    {wh.events.join(", ")} &middot;{" "}
+                    <span className={wh.active ? "text-green-600" : "text-gray-400"}>
+                      {wh.active ? "Active" : "Inactive"}
+                    </span>
+                  </p>
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    onClick={() => setSelectedWebhook(selectedWebhook?.id === wh.id ? null : wh)}
+                    className="rounded border px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                  >
+                    {selectedWebhook?.id === wh.id ? "Hide deliveries" : "Deliveries"}
+                  </button>
+                  <button
+                    onClick={() => openEdit(wh)}
+                    className="rounded border px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteMutation.mutate(wh.id)}
+                    disabled={deleteMutation.isPending}
+                    className="rounded border border-red-200 px-2 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-40"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+
+              {selectedWebhook?.id === wh.id && (
+                <div className="mt-4 border-t pt-4">
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Delivery history
+                  </h3>
+                  {deliveriesLoading ? (
+                    <p className="text-xs text-gray-400">Loading…</p>
+                  ) : deliveries.length === 0 ? (
+                    <p className="text-xs text-gray-400">No deliveries yet.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {deliveries.map((d: WebhookDelivery) => (
+                        <div
+                          key={d.id}
+                          className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-xs"
+                        >
+                          <div className="flex items-center gap-3">
+                            <span
+                              className={
+                                d.status === "success"
+                                  ? "text-green-600"
+                                  : d.status === "failed"
+                                  ? "text-red-600"
+                                  : "text-yellow-600"
+                              }
+                            >
+                              {d.status}
+                            </span>
+                            <span className="text-gray-500">{d.event}</span>
+                            {d.response_code && (
+                              <span className="text-gray-400">HTTP {d.response_code}</span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-gray-400">
+                              {new Date(d.created_at).toLocaleString()}
+                            </span>
+                            {d.status === "failed" && (
+                              <button
+                                onClick={() =>
+                                  retryMutation.mutate({ webhookId: wh.id, deliveryId: d.id })
+                                }
+                                disabled={retryMutation.isPending}
+                                className="rounded border border-blue-200 px-2 py-0.5 text-blue-600 hover:bg-blue-50 disabled:opacity-40"
+                              >
+                                Retry
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -12,6 +12,7 @@ const Navigation = () => {
         <Link href="/">Dashboard</Link> |{" "}
         <Link href="/outages">Outages</Link> |{" "}
         <Link href="/bulk-import">Bulk Import</Link> |{" "}
+        <Link href="/webhooks">Webhooks</Link> |{" "}
         <Link href="/payments">Payments</Link> |{" "}
         <Link href="/setting">Wallet &amp; Settings</Link>
       </div>

--- a/src/components/bulk-import/bulk-import-view.tsx
+++ b/src/components/bulk-import/bulk-import-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRef, useState } from "react";
 
 import { bulkImportOutages } from "@/services/bulkImportService";
@@ -91,7 +92,15 @@ export default function BulkImportView() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
       <div className="space-y-2">
-        <h1 className="text-2xl font-bold text-gray-800">Bulk Outage Import</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-gray-800">Bulk Outage Import</h1>
+          <Link
+            href="/bulk-import/history"
+            className="text-sm text-blue-600 hover:underline"
+          >
+            View history →
+          </Link>
+        </div>
         <p className="text-sm text-gray-500">
           Upload a `.csv` or `.json` file to create outages in one pass.
         </p>

--- a/src/services/bulkImportService.ts
+++ b/src/services/bulkImportService.ts
@@ -1,5 +1,5 @@
 import { api } from "@/lib/api";
-import { BulkImportResult } from "../types/bulkImport";
+import { BulkImportResult, BulkImportRecord } from "../types/bulkImport";
 
 export const bulkImportOutages = async (
   file: File
@@ -12,5 +12,10 @@ export const bulkImportOutages = async (
     formData,
     { headers: { "Content-Type": "multipart/form-data" } }
   );
+  return response.data;
+};
+
+export const fetchBulkImportHistory = async (): Promise<BulkImportRecord[]> => {
+  const response = await api.get<BulkImportRecord[]>("/outages/bulk/history");
   return response.data;
 };

--- a/src/services/webhookService.ts
+++ b/src/services/webhookService.ts
@@ -1,0 +1,35 @@
+import { api } from "@/lib/api";
+import type {
+  Webhook,
+  WebhookDelivery,
+  CreateWebhookPayload,
+  UpdateWebhookPayload,
+} from "@/types/webhook";
+
+export const fetchWebhooks = async (): Promise<Webhook[]> => {
+  const res = await api.get<Webhook[]>("/webhooks");
+  return res.data;
+};
+
+export const createWebhook = async (payload: CreateWebhookPayload): Promise<Webhook> => {
+  const res = await api.post<Webhook>("/webhooks", payload);
+  return res.data;
+};
+
+export const updateWebhook = async (id: string, payload: UpdateWebhookPayload): Promise<Webhook> => {
+  const res = await api.patch<Webhook>(`/webhooks/${id}`, payload);
+  return res.data;
+};
+
+export const deleteWebhook = async (id: string): Promise<void> => {
+  await api.delete(`/webhooks/${id}`);
+};
+
+export const fetchWebhookDeliveries = async (webhookId: string): Promise<WebhookDelivery[]> => {
+  const res = await api.get<WebhookDelivery[]>(`/webhooks/${webhookId}/deliveries`);
+  return res.data;
+};
+
+export const retryDelivery = async (webhookId: string, deliveryId: string): Promise<void> => {
+  await api.post(`/webhooks/${webhookId}/deliveries/${deliveryId}/retry`);
+};

--- a/src/types/bulkImport.ts
+++ b/src/types/bulkImport.ts
@@ -9,3 +9,13 @@ export interface BulkImportResult {
   skipped: number;
   errors: ImportValidationError[];
 }
+
+export interface BulkImportRecord {
+  id: string;
+  filename: string;
+  imported: number;
+  skipped: number;
+  error_count: number;
+  errors: ImportValidationError[];
+  created_at: string;
+}

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -1,0 +1,27 @@
+export interface Webhook {
+  id: string;
+  url: string;
+  events: string[];
+  active: boolean;
+  created_at: string;
+}
+
+export interface WebhookDelivery {
+  id: string;
+  webhook_id: string;
+  event: string;
+  status: "success" | "failed" | "pending";
+  response_code: number | null;
+  created_at: string;
+}
+
+export interface CreateWebhookPayload {
+  url: string;
+  events: string[];
+}
+
+export interface UpdateWebhookPayload {
+  url?: string;
+  events?: string[];
+  active?: boolean;
+}


### PR DESCRIPTION
Closes #95, closes #96, closes #92, closes #93

## Summary

Implements all four issues assigned to Tinna23:

**FE-051 (#95) — Login route and session bootstrap flow**
- `src/app/login/page.tsx`: form submitting to `POST /auth/login`, redirects to `/` on success, surfaces invalid-credential and network errors

**FE-052 (#96) — Registration route**
- `src/app/register/page.tsx`: typed form with client-side validation (password match, min length), `POST /auth/register` then auto-login, duplicate email errors rendered from API response

**FE-025 (#92) — Webhook management screens**
- `src/types/webhook.ts`, `src/services/webhookService.ts`: full CRUD + delivery history + retry
- `src/app/webhooks/page.tsx`: list, create, edit, delete webhooks; inline delivery history with per-delivery retry for failed deliveries
- Webhooks link added to Navigation

**FE-026 (#93) — Bulk import history and results page**
- `src/types/bulkImport.ts`: added `BulkImportRecord`
- `src/services/bulkImportService.ts`: added `fetchBulkImportHistory` calling `GET /outages/bulk/history`
- `src/app/bulk-import/history/page.tsx`: lists previous imports with counts and expandable error details
- `src/components/bulk-import/bulk-import-view.tsx`: added "View history" link

## Verification

`npm run build` passes with all 13 routes compiling cleanly.
