### PR TITLE
feat: outages table controls, delete confirmation, location map, post-incident analysis

### DIFF
--- a/src/app/outages/[id]/page.tsx
+++ b/src/app/outages/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 import { ResolveOutageModal } from "@/features/outages/components/ResolveOutageModal";
 import { SLADisputesPanel } from "@/components/outages/SLADisputesPanel";
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { Separator } from "@/components/ui/separator";
-import { getOutage, resolveOutage } from "@/services/outages";
+import { getOutage, resolveOutage, deleteOutage } from "@/services/outages";
 import type { Outage, OutageResolutionPayment } from "@/types/outages";
 
 function getErrorMessage(error: unknown) {
@@ -18,6 +18,7 @@ function getErrorMessage(error: unknown) {
 
 export default function OutageDetailsPage() {
   const params = useParams<{ id: string }>();
+  const router = useRouter();
   const id = params?.id;
   const [outage, setOutage] = useState<Outage | null>(null);
   const [loading, setLoading] = useState(true);
@@ -25,6 +26,11 @@ export default function OutageDetailsPage() {
   const [error, setError] = useState<string | null>(null);
   const [isResolveModalOpen, setIsResolveModalOpen] = useState(false);
   const [resolutionPayment, setResolutionPayment] = useState<OutageResolutionPayment | null>(null);
+
+  // Delete state
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const isFetching = useRef(false);
   const hasOutageRef = useRef(false);
@@ -100,6 +106,19 @@ export default function OutageDetailsPage() {
     }
   }
 
+  async function handleDelete() {
+    if (!id) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteOutage(id);
+      router.push("/outages");
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Deletion failed. Please try again.");
+      setDeleting(false);
+    }
+  }
+
   if (loading) {
     return (
       <RouteLoadingState
@@ -144,17 +163,25 @@ export default function OutageDetailsPage() {
           </Badge>
         </div>
 
-        <button
-          onClick={() => setIsResolveModalOpen(true)}
-          disabled={isResolved || resolving}
-          className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-            isResolved
-              ? "cursor-not-allowed bg-gray-100 text-gray-500"
-              : "bg-blue-600 text-white hover:bg-blue-700"
-          }`}
-        >
-          {isResolved ? "Outage Resolved" : resolving ? "Resolving…" : "Resolve Outage"}
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setIsResolveModalOpen(true)}
+            disabled={isResolved || resolving}
+            className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+              isResolved
+                ? "cursor-not-allowed bg-gray-100 text-gray-500"
+                : "bg-blue-600 text-white hover:bg-blue-700"
+            }`}
+          >
+            {isResolved ? "Outage Resolved" : resolving ? "Resolving…" : "Resolve Outage"}
+          </button>
+          <button
+            onClick={() => { setShowDeleteConfirm(true); setDeleteError(null); }}
+            className="rounded-md border border-red-200 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 transition-colors"
+          >
+            Delete
+          </button>
+        </div>
       </div>
 
       {error ? (
@@ -292,6 +319,70 @@ export default function OutageDetailsPage() {
           </CardContent>
         </Card>
 
+        {/* FE-063: Location visualization */}
+        <Card className="md:col-span-2">
+          <CardHeader className="pb-3">
+            <CardTitle>Location</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm">
+            {outage.location ? (
+              <div className="space-y-3">
+                <div className="flex flex-wrap gap-6">
+                  <div>
+                    <span className="text-muted-foreground">Latitude</span>
+                    <p className="font-medium font-mono">{outage.location.latitude.toFixed(6)}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Longitude</span>
+                    <p className="font-medium font-mono">{outage.location.longitude.toFixed(6)}</p>
+                  </div>
+                </div>
+                <div className="relative w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-50" style={{ paddingBottom: "40%" }}>
+                  {/* Static map via OpenStreetMap tile — no API key required */}
+                  <iframe
+                    title="Outage location map"
+                    className="absolute inset-0 h-full w-full"
+                    src={`https://www.openstreetmap.org/export/embed.html?bbox=${outage.location.longitude - 0.05},${outage.location.latitude - 0.05},${outage.location.longitude + 0.05},${outage.location.latitude + 0.05}&layer=mapnik&marker=${outage.location.latitude},${outage.location.longitude}`}
+                    loading="lazy"
+                    referrerPolicy="no-referrer"
+                  />
+                </div>
+                <p className="text-xs text-slate-400">
+                  Map data © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer" className="underline">OpenStreetMap</a> contributors
+                </p>
+              </div>
+            ) : (
+              <span className="italic text-muted-foreground">No location data available for this outage.</span>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* FE-064: Root cause and resolution notes */}
+        <Card className="md:col-span-2">
+          <CardHeader className="pb-3">
+            <CardTitle>Post-Incident Analysis</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div>
+              <p className="font-medium text-slate-700 mb-1">Root Cause</p>
+              {outage.root_cause ? (
+                <p className="text-slate-900 whitespace-pre-wrap">{outage.root_cause}</p>
+              ) : (
+                <p className="italic text-muted-foreground">No root cause recorded.</p>
+              )}
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium text-slate-700 mb-1">Resolution Notes</p>
+              {outage.resolution_notes ? (
+                <p className="text-slate-900 whitespace-pre-wrap">{outage.resolution_notes}</p>
+              ) : (
+                <p className="italic text-muted-foreground">No resolution notes recorded.</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
         <SLADisputesPanel outageId={outage.id} canResolve={isResolved} />
       </div>
 
@@ -312,6 +403,55 @@ export default function OutageDetailsPage() {
         }}
         onConfirmResolve={handleResolve}
       />
+
+      {/* FE-062: Delete confirmation dialog */}
+      {showDeleteConfirm && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-dialog-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+        >
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl space-y-4">
+            <h2 id="delete-dialog-title" className="text-lg font-semibold text-slate-900">
+              Delete outage?
+            </h2>
+            <p className="text-sm text-slate-600">
+              This will permanently delete outage{" "}
+              <span className="font-medium">{outage.id}</span> ({outage.site_name}). This action
+              cannot be undone.
+            </p>
+            {deleteError && (
+              <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+                {deleteError}{" "}
+                <button
+                  className="underline font-medium"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => { setShowDeleteConfirm(false); setDeleteError(null); }}
+                disabled={deleting}
+                className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium hover:bg-slate-50 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleting ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/outages/components/outages-page-client.tsx
+++ b/src/app/outages/components/outages-page-client.tsx
@@ -1,246 +1,380 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+import type { VisibilityState } from "@tanstack/react-table";
 
-import { DataTable } from "@/components/data-table";
+import { DataTable, type TableDensity } from "@/components/data-table";
 import ExportDropdown from "@/components/outages/ExportDropdown";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { useOutages } from "@/features/outages/hooks/useOutages";
 import { useFilterPresets, useOutagesTableState } from "@/hooks/useOutagesTableState";
+import { deleteOutage } from "@/services/outages";
 import type { Outage } from "@/types/outages";
 import type { ColumnDef } from "@tanstack/react-table";
 
-const columns: ColumnDef<Outage>[] = [
-  {
-    accessorKey: "id",
-    header: "Outage",
-    cell: ({ row }) => (
-      <Link
-        href={`/outages/${row.original.id}`}
-        className="font-medium text-blue-600 underline-offset-4 hover:underline"
-      >
-        {row.original.id}
-      </Link>
-    ),
-  },
-  {
-    accessorKey: "site_name",
-    header: "Site",
-  },
-  {
-    accessorKey: "severity",
-    header: "Severity",
-    cell: ({ row }) => (
-      <Badge variant={row.original.severity === "critical" ? "destructive" : "secondary"}>
-        {row.original.severity}
-      </Badge>
-    ),
-  },
-  {
-    accessorKey: "status",
-    header: "Status",
-    cell: ({ row }) => (
-      <Badge variant={row.original.status === "resolved" ? "secondary" : "outline"}>
-        {row.original.status}
-      </Badge>
-    ),
-  },
-  {
-    accessorKey: "detected_at",
-    header: "Detected",
-    cell: ({ row }) => new Date(row.original.detected_at).toLocaleString(),
-  },
-  {
-    accessorKey: "affected_services",
-    header: "Services",
-    cell: ({ row }) => row.original.affected_services.join(", "),
-  },
-];
+const VISIBILITY_KEY = "outages-table-visibility";
+const DENSITY_KEY = "outages-table-density";
+
+function loadFromStorage<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+const DEFAULT_VISIBILITY: VisibilityState = {
+  id: true,
+  site_name: true,
+  severity: true,
+  status: true,
+  detected_at: true,
+  affected_services: true,
+};
+
+// Non-critical columns that can be toggled off
+const OPTIONAL_COLUMNS = new Set(["detected_at", "affected_services"]);
 
 export function OutagesPageClient() {
-    const { state, actions } = useOutagesTableState();
-    const { presets, savePreset, deletePreset } = useFilterPresets();
-    const { data, isLoading, isError } = useOutages(state);
-    const totalItems = data?.total ?? 0;
-    const totalPages = Math.max(1, Math.ceil(totalItems / state.page_size));
-    const [presetName, setPresetName] = useState("");
+  const { state, actions } = useOutagesTableState();
+  const { presets, savePreset, deletePreset } = useFilterPresets();
+  const { data, isLoading, isError, refetch } = useOutages(state);
+  const totalItems = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalItems / state.page_size));
+  const [presetName, setPresetName] = useState("");
 
-    if (isLoading) {
-        return (
-            <RouteLoadingState
-                title="Loading outages"
-                description="Gathering the latest incidents and applying your saved filters."
-            />
-        );
+  // Column visibility (persisted)
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() =>
+    loadFromStorage(VISIBILITY_KEY, DEFAULT_VISIBILITY)
+  );
+
+  // Density (persisted)
+  const [density, setDensity] = useState<TableDensity>(() =>
+    loadFromStorage<TableDensity>(DENSITY_KEY, "default")
+  );
+
+  // Delete confirmation state
+  const [pendingDelete, setPendingDelete] = useState<Outage | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem(VISIBILITY_KEY, JSON.stringify(columnVisibility));
+  }, [columnVisibility]);
+
+  useEffect(() => {
+    localStorage.setItem(DENSITY_KEY, JSON.stringify(density));
+  }, [density]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!pendingDelete) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteOutage(pendingDelete.id);
+      setPendingDelete(null);
+      await refetch();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Deletion failed. Please try again.");
+    } finally {
+      setDeleting(false);
     }
+  }, [pendingDelete, refetch]);
 
-    if (isError) {
-        return (
-            <RouteErrorState
-                title="Outages unavailable"
-                description="We could not load the outage feed right now."
-                actionLabel="Reload page"
-                onAction={() => window.location.reload()}
-            />
-        );
-    }
+  const columns: ColumnDef<Outage>[] = [
+    {
+      accessorKey: "id",
+      header: "Outage",
+      cell: ({ row }) => (
+        <Link
+          href={`/outages/${row.original.id}`}
+          className="font-medium text-blue-600 underline-offset-4 hover:underline"
+        >
+          {row.original.id}
+        </Link>
+      ),
+    },
+    {
+      accessorKey: "site_name",
+      header: "Site",
+    },
+    {
+      accessorKey: "severity",
+      header: "Severity",
+      cell: ({ row }) => (
+        <Badge variant={row.original.severity === "critical" ? "destructive" : "secondary"}>
+          {row.original.severity}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: "status",
+      header: "Status",
+      cell: ({ row }) => (
+        <Badge variant={row.original.status === "resolved" ? "secondary" : "outline"}>
+          {row.original.status}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: "detected_at",
+      header: "Detected",
+      cell: ({ row }) => new Date(row.original.detected_at).toLocaleString(),
+    },
+    {
+      accessorKey: "affected_services",
+      header: "Services",
+      cell: ({ row }) => row.original.affected_services.join(", "),
+    },
+    {
+      id: "actions",
+      header: "Actions",
+      cell: ({ row }) => (
+        <button
+          onClick={() => { setPendingDelete(row.original); setDeleteError(null); }}
+          className="rounded px-2 py-1 text-xs text-red-600 border border-red-200 hover:bg-red-50"
+          aria-label={`Delete outage ${row.original.id}`}
+        >
+          Delete
+        </button>
+      ),
+    },
+  ];
 
-    const outages: Outage[] = data?.items ?? [];
-
+  if (isLoading) {
     return (
-        <div className="space-y-6 p-6">
-            <div className="space-y-1">
-                <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Outages</h1>
-                <p className="text-sm text-slate-500">
-                    Review live incidents, filter by severity and status, and page through the active outage feed.
-                </p>
-            </div>
-
-            <div className="flex justify-end">
-                <ExportDropdown
-                    filters={{
-                        severity: state.severity,
-                        status: state.status,
-                    }}
-                />
-            </div>
-
-            {/* Filter presets */}
-            <div className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-                <span className="text-xs font-medium text-slate-500 uppercase tracking-wide">Presets:</span>
-                {presets.map((preset) => (
-                    <div key={preset.name} className="flex items-center gap-1">
-                        <button
-                            className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100"
-                            onClick={() => {
-                                actions.setSeverity(preset.severity);
-                                actions.setStatus(preset.status);
-                            }}
-                        >
-                            {preset.name}
-                        </button>
-                        <button
-                            className="text-slate-400 hover:text-red-500 text-xs"
-                            onClick={() => deletePreset(preset.name)}
-                            aria-label={`Delete preset ${preset.name}`}
-                        >
-                            ×
-                        </button>
-                    </div>
-                ))}
-                <div className="ml-auto flex items-center gap-2">
-                    <input
-                        className="rounded-md border border-slate-200 px-2 py-1 text-xs"
-                        placeholder="Preset name"
-                        value={presetName}
-                        onChange={(e) => setPresetName(e.target.value)}
-                    />
-                    <Button
-                        variant="outline"
-                        className="text-xs h-7 px-2"
-                        disabled={!presetName.trim()}
-                        onClick={() => {
-                            savePreset({ name: presetName.trim(), severity: state.severity, status: state.status });
-                            setPresetName("");
-                        }}
-                    >
-                        Save preset
-                    </Button>
-                </div>
-            </div>
-
-            <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
-                <label className="space-y-2 text-sm">
-                    <span className="font-medium text-slate-700">Severity</span>
-                    <select
-                        className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        value={state.severity ?? ""}
-                        onChange={(event) => actions.setSeverity(event.target.value || undefined)}
-                    >
-                        <option value="">All severities</option>
-                        <option value="critical">Critical</option>
-                        <option value="high">High</option>
-                        <option value="medium">Medium</option>
-                        <option value="low">Low</option>
-                    </select>
-                </label>
-
-                <label className="space-y-2 text-sm">
-                    <span className="font-medium text-slate-700">Status</span>
-                    <select
-                        className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        value={state.status ?? ""}
-                        onChange={(event) => actions.setStatus(event.target.value || undefined)}
-                    >
-                        <option value="">All statuses</option>
-                        <option value="open">Open</option>
-                        <option value="resolved">Resolved</option>
-                    </select>
-                </label>
-
-                <label className="space-y-2 text-sm">
-                    <span className="font-medium text-slate-700">Rows per page</span>
-                    <select
-                        className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        value={state.page_size}
-                        onChange={(event) => actions.setPageSize(Number(event.target.value))}
-                    >
-                        {[10, 20, 50].map((size) => (
-                            <option key={size} value={size}>
-                                {size}
-                            </option>
-                        ))}
-                    </select>
-                </label>
-
-                <div className="rounded-lg bg-slate-50 p-4">
-                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                        Result count
-                    </p>
-                    <p className="mt-2 text-2xl font-semibold text-slate-900">{totalItems}</p>
-                    <p className="mt-1 text-sm text-slate-500">
-                        Page {state.page} of {totalPages}
-                    </p>
-                </div>
-            </div>
-
-            {outages.length === 0 ? (
-                <RouteEmptyState
-                    title="No outages found"
-                    description="Try widening your filters or lowering the severity restriction."
-                />
-            ) : (
-                <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                    <DataTable columns={columns} data={outages} />
-
-                    <div className="flex flex-col gap-3 border-t border-slate-100 pt-4 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between">
-                        <span>
-                            Showing {(state.page - 1) * state.page_size + 1}-
-                            {Math.min(state.page * state.page_size, totalItems)} of {totalItems}
-                        </span>
-
-                        <div className="flex items-center gap-2">
-                            <Button
-                                variant="outline"
-                                onClick={() => actions.setPage(state.page - 1)}
-                                disabled={state.page <= 1}
-                            >
-                                Previous
-                            </Button>
-                            <Button
-                                variant="outline"
-                                onClick={() => actions.setPage(state.page + 1)}
-                                disabled={state.page >= totalPages}
-                            >
-                                Next
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-            )}
-        </div>
+      <RouteLoadingState
+        title="Loading outages"
+        description="Gathering the latest incidents and applying your saved filters."
+      />
     );
+  }
+
+  if (isError) {
+    return (
+      <RouteErrorState
+        title="Outages unavailable"
+        description="We could not load the outage feed right now."
+        actionLabel="Reload page"
+        onAction={() => window.location.reload()}
+      />
+    );
+  }
+
+  const outages: Outage[] = data?.items ?? [];
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Outages</h1>
+        <p className="text-sm text-slate-500">
+          Review live incidents, filter by severity and status, and page through the active outage feed.
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <ExportDropdown
+          filters={{
+            severity: state.severity,
+            status: state.status,
+          }}
+        />
+      </div>
+
+      {/* Filter presets */}
+      <div className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+        <span className="text-xs font-medium text-slate-500 uppercase tracking-wide">Presets:</span>
+        {presets.map((preset) => (
+          <div key={preset.name} className="flex items-center gap-1">
+            <button
+              className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100"
+              onClick={() => {
+                actions.setSeverity(preset.severity);
+                actions.setStatus(preset.status);
+              }}
+            >
+              {preset.name}
+            </button>
+            <button
+              className="text-slate-400 hover:text-red-500 text-xs"
+              onClick={() => deletePreset(preset.name)}
+              aria-label={`Delete preset ${preset.name}`}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <div className="ml-auto flex items-center gap-2">
+          <input
+            className="rounded-md border border-slate-200 px-2 py-1 text-xs"
+            placeholder="Preset name"
+            value={presetName}
+            onChange={(e) => setPresetName(e.target.value)}
+          />
+          <Button
+            variant="outline"
+            className="text-xs h-7 px-2"
+            disabled={!presetName.trim()}
+            onClick={() => {
+              savePreset({ name: presetName.trim(), severity: state.severity, status: state.status });
+              setPresetName("");
+            }}
+          >
+            Save preset
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
+        <label className="space-y-2 text-sm">
+          <span className="font-medium text-slate-700">Severity</span>
+          <select
+            className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
+            value={state.severity ?? ""}
+            onChange={(event) => actions.setSeverity(event.target.value || undefined)}
+          >
+            <option value="">All severities</option>
+            <option value="critical">Critical</option>
+            <option value="high">High</option>
+            <option value="medium">Medium</option>
+            <option value="low">Low</option>
+          </select>
+        </label>
+
+        <label className="space-y-2 text-sm">
+          <span className="font-medium text-slate-700">Status</span>
+          <select
+            className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
+            value={state.status ?? ""}
+            onChange={(event) => actions.setStatus(event.target.value || undefined)}
+          >
+            <option value="">All statuses</option>
+            <option value="open">Open</option>
+            <option value="resolved">Resolved</option>
+          </select>
+        </label>
+
+        <label className="space-y-2 text-sm">
+          <span className="font-medium text-slate-700">Rows per page</span>
+          <select
+            className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
+            value={state.page_size}
+            onChange={(event) => actions.setPageSize(Number(event.target.value))}
+          >
+            {[10, 20, 50].map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="rounded-lg bg-slate-50 p-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            Result count
+          </p>
+          <p className="mt-2 text-2xl font-semibold text-slate-900">{totalItems}</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Page {state.page} of {totalPages}
+          </p>
+        </div>
+      </div>
+
+      {outages.length === 0 ? (
+        <RouteEmptyState
+          title="No outages found"
+          description="Try widening your filters or lowering the severity restriction."
+        />
+      ) : (
+        <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <DataTable
+            columns={columns}
+            data={outages}
+            columnVisibility={columnVisibility}
+            onColumnVisibilityChange={setColumnVisibility}
+            density={density}
+            onDensityChange={setDensity}
+          />
+
+          <div className="flex flex-col gap-3 border-t border-slate-100 pt-4 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+            <span>
+              Showing {(state.page - 1) * state.page_size + 1}-
+              {Math.min(state.page * state.page_size, totalItems)} of {totalItems}
+            </span>
+
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => actions.setPage(state.page - 1)}
+                disabled={state.page <= 1}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => actions.setPage(state.page + 1)}
+                disabled={state.page >= totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation dialog */}
+      {pendingDelete && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-dialog-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+        >
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl space-y-4">
+            <h2 id="delete-dialog-title" className="text-lg font-semibold text-slate-900">
+              Delete outage?
+            </h2>
+            <p className="text-sm text-slate-600">
+              This will permanently delete outage{" "}
+              <span className="font-medium">{pendingDelete.id}</span> (
+              {pendingDelete.site_name}). This action cannot be undone.
+            </p>
+            {deleteError && (
+              <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+                {deleteError}{" "}
+                <button
+                  className="underline font-medium"
+                  onClick={handleDeleteConfirm}
+                  disabled={deleting}
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => { setPendingDelete(null); setDeleteError(null); }}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDeleteConfirm}
+                disabled={deleting}
+              >
+                {deleting ? "Deleting…" : "Delete"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -2,6 +2,7 @@
 
 import {
     type ColumnDef,
+    type VisibilityState,
     flexRender,
     getCoreRowModel,
     useReactTable,
@@ -15,42 +16,111 @@ import {
     TableRow,
 } from "@/components/ui/table";
 
+export type TableDensity = "default" | "compact";
+
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[];
     data: TData[];
+    columnVisibility?: VisibilityState;
+    onColumnVisibilityChange?: (visibility: VisibilityState) => void;
+    density?: TableDensity;
+    onDensityChange?: (density: TableDensity) => void;
 }
 
-export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData, TValue>) {
+export function DataTable<TData, TValue>({
+    columns,
+    data,
+    columnVisibility,
+    onColumnVisibilityChange,
+    density = "default",
+    onDensityChange,
+}: DataTableProps<TData, TValue>) {
     const table = useReactTable({
         data,
         columns,
         getCoreRowModel: getCoreRowModel(),
+        state: { columnVisibility: columnVisibility ?? {} },
+        onColumnVisibilityChange: (updater) => {
+            if (!onColumnVisibilityChange) return;
+            const next =
+                typeof updater === "function"
+                    ? updater(columnVisibility ?? {})
+                    : updater;
+            onColumnVisibilityChange(next);
+        },
     });
 
+    const cellPadding = density === "compact" ? "py-1 px-2 text-xs" : "py-2 px-4 text-sm";
+
     return (
-        <Table>
-            <TableHeader>
-                {table.getHeaderGroups().map((hg) => (
-                    <TableRow key={hg.id}>
-                        {hg.headers.map((h) => (
-                            <TableHead key={h.id}>
-                                {flexRender(h.column.columnDef.header, h.getContext())}
-                            </TableHead>
-                        ))}
-                    </TableRow>
-                ))}
-            </TableHeader>
-            <TableBody>
-                {table.getRowModel().rows.map((row) => (
-                    <TableRow key={row.id}>
-                        {row.getVisibleCells().map((cell) => (
-                            <TableCell key={cell.id}>
-                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                            </TableCell>
-                        ))}
-                    </TableRow>
-                ))}
-            </TableBody>
-        </Table>
+        <div className="space-y-2">
+            {(onColumnVisibilityChange || onDensityChange) && (
+                <div className="flex flex-wrap items-center gap-3 pb-1">
+                    {onDensityChange && (
+                        <div className="flex items-center gap-1 text-xs text-slate-600">
+                            <span className="font-medium">Density:</span>
+                            {(["default", "compact"] as TableDensity[]).map((d) => (
+                                <button
+                                    key={d}
+                                    onClick={() => onDensityChange(d)}
+                                    className={`rounded px-2 py-0.5 capitalize border ${
+                                        density === d
+                                            ? "bg-slate-800 text-white border-slate-800"
+                                            : "border-slate-200 hover:bg-slate-100"
+                                    }`}
+                                >
+                                    {d}
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                    {onColumnVisibilityChange && (
+                        <div className="flex flex-wrap items-center gap-1 text-xs text-slate-600">
+                            <span className="font-medium">Columns:</span>
+                            {table.getAllLeafColumns().map((col) => {
+                                const header = col.columnDef.header;
+                                const label = typeof header === "string" ? header : col.id;
+                                return (
+                                    <label key={col.id} className="flex items-center gap-1 cursor-pointer select-none">
+                                        <input
+                                            type="checkbox"
+                                            checked={col.getIsVisible()}
+                                            onChange={col.getToggleVisibilityHandler()}
+                                            className="accent-slate-800"
+                                        />
+                                        {label}
+                                    </label>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            <Table>
+                <TableHeader>
+                    {table.getHeaderGroups().map((hg) => (
+                        <TableRow key={hg.id}>
+                            {hg.headers.map((h) => (
+                                <TableHead key={h.id} className={cellPadding}>
+                                    {flexRender(h.column.columnDef.header, h.getContext())}
+                                </TableHead>
+                            ))}
+                        </TableRow>
+                    ))}
+                </TableHeader>
+                <TableBody>
+                    {table.getRowModel().rows.map((row) => (
+                        <TableRow key={row.id}>
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id} className={cellPadding}>
+                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
     );
 }

--- a/src/types/outages.ts
+++ b/src/types/outages.ts
@@ -45,6 +45,8 @@ export interface Outage {
   created_by?: string;
   location?: Location;
   sla_status?: SLAResult;
+  root_cause?: string;
+  resolution_notes?: string;
 }
 
 export interface OutageCreate {


### PR DESCRIPTION
## Summary

Implements four issues assigned to @NteinPrecious.

### FE-061 — Column visibility and density controls (#105)
- `DataTable` now accepts `columnVisibility`, `onColumnVisibilityChange`, `density`, and `onDensityChange` props
- Outages list page renders per-column visibility checkboxes and a compact/default density toggle
- Both preferences are persisted to `localStorage` and restored on revisit

### FE-062 — Outage deletion confirmation and recovery UX (#106)
- Delete button added to the outages list (per-row) and the outage detail page header
- A modal confirmation dialog is shown before any deletion is executed
- On failure, an inline error with a **Retry** link is surfaced; the dialog stays open so the user can recover

### FE-063 — Outage location map visualization (#107)
- New **Location** card on the outage detail page
- Shows latitude/longitude in monospace and embeds an OpenStreetMap iframe centred on the coordinates (no API key required)
- Falls back to an explicit empty state when `location` is absent; iframe is responsive on mobile

### FE-064 — Root-cause and resolution-notes section (#108)
- `root_cause` and `resolution_notes` optional fields added to the `Outage` type in `src/types/outages.ts`
- New **Post-Incident Analysis** card on the outage detail page renders both fields
- Explicit empty states shown when either field is absent

## Testing
- `npm run build` passes with zero errors
- Existing card layout and SLA/payment flows are unchanged

Closes #105
Closes #106
Closes #107
Closes #108