### PR TITLE
feat: FE-017/018/020/022 outage create, edit, timeline, wallet readiness

### DIFF
--- a/src/app/outages/[id]/page.tsx
+++ b/src/app/outages/[id]/page.tsx
@@ -9,11 +9,28 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { Separator } from "@/components/ui/separator";
-import { getOutage, resolveOutage } from "@/services/outages";
-import type { Outage, OutageResolutionPayment } from "@/types/outages";
+import { getOutage, resolveOutage, updateOutage } from "@/services/outages";
+import type { Outage, OutageResolutionPayment, OutageUpdate, Severity, OutageStatus } from "@/types/outages";
 
 function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Failed to load outage";
+}
+
+// FE-020: derive timeline events from outage data
+function buildTimeline(outage: Outage) {
+  const events: { label: string; time: string; note?: string }[] = [];
+  events.push({ label: "Outage detected", time: outage.detected_at });
+  if (outage.sla_status) {
+    events.push({
+      label: "SLA computed",
+      time: outage.resolved_at ?? outage.detected_at,
+      note: `${outage.sla_status.status} · ${outage.sla_status.rating}`,
+    });
+  }
+  if (outage.resolved_at) {
+    events.push({ label: "Outage resolved", time: outage.resolved_at });
+  }
+  return events.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
 }
 
 export default function OutageDetailsPage() {
@@ -26,6 +43,11 @@ export default function OutageDetailsPage() {
   const [isResolveModalOpen, setIsResolveModalOpen] = useState(false);
   const [resolutionPayment, setResolutionPayment] = useState<OutageResolutionPayment | null>(null);
 
+  // FE-018: edit state
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [editForm, setEditForm] = useState<OutageUpdate>({});
+
   const isFetching = useRef(false);
   const hasOutageRef = useRef(false);
 
@@ -34,18 +56,12 @@ export default function OutageDetailsPage() {
   }, [outage]);
 
   useEffect(() => {
-    if (!id) {
-      return;
-    }
-
+    if (!id) return;
     let isMounted = true;
 
     const fetchOutage = async () => {
-      if (isFetching.current) {
-        return;
-      }
+      if (isFetching.current) return;
       isFetching.current = true;
-
       try {
         const data = await getOutage(id);
         if (isMounted) {
@@ -58,39 +74,56 @@ export default function OutageDetailsPage() {
         }
       } finally {
         isFetching.current = false;
-        if (isMounted) {
-          setLoading(false);
-        }
+        if (isMounted) setLoading(false);
       }
     };
 
     void fetchOutage();
-
     const intervalId =
       outage?.status === "resolved" ? null : setInterval(() => void fetchOutage(), 15000);
 
     return () => {
       isMounted = false;
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
+      if (intervalId) clearInterval(intervalId);
     };
   }, [id, outage?.status]);
 
-  async function handleResolve(mttrMinutes: number) {
-    if (!id) {
-      return;
-    }
+  function startEdit() {
+    if (!outage) return;
+    setEditForm({
+      site_name: outage.site_name,
+      severity: outage.severity,
+      status: outage.status,
+      description: outage.description,
+      affected_services: outage.affected_services,
+      affected_subscribers: outage.affected_subscribers,
+      assigned_to: outage.assigned_to,
+    });
+    setEditing(true);
+  }
 
+  async function handleSaveEdit() {
+    if (!id || !outage) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateOutage(id, editForm);
+      setOutage({ ...outage, ...updated });
+      setEditing(false);
+    } catch (issue) {
+      setError(getErrorMessage(issue));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleResolve(mttrMinutes: number) {
+    if (!id) return;
     setResolving(true);
     setError(null);
-
     try {
       const updated = await resolveOutage(id, { mttr_minutes: mttrMinutes });
-      setOutage({
-        ...updated.outage,
-        sla_status: updated.sla,
-      });
+      setOutage({ ...updated.outage, sla_status: updated.sla });
       setResolutionPayment(updated.payment);
       setIsResolveModalOpen(false);
     } catch (issue) {
@@ -130,6 +163,7 @@ export default function OutageDetailsPage() {
   }
 
   const isResolved = outage.status === "resolved";
+  const timeline = buildTimeline(outage);
 
   return (
     <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
@@ -144,17 +178,27 @@ export default function OutageDetailsPage() {
           </Badge>
         </div>
 
-        <button
-          onClick={() => setIsResolveModalOpen(true)}
-          disabled={isResolved || resolving}
-          className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-            isResolved
-              ? "cursor-not-allowed bg-gray-100 text-gray-500"
-              : "bg-blue-600 text-white hover:bg-blue-700"
-          }`}
-        >
-          {isResolved ? "Outage Resolved" : resolving ? "Resolving…" : "Resolve Outage"}
-        </button>
+        <div className="flex gap-2">
+          {!editing && (
+            <button
+              onClick={startEdit}
+              className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Edit
+            </button>
+          )}
+          <button
+            onClick={() => setIsResolveModalOpen(true)}
+            disabled={isResolved || resolving}
+            className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+              isResolved
+                ? "cursor-not-allowed bg-gray-100 text-gray-500"
+                : "bg-blue-600 text-white hover:bg-blue-700"
+            }`}
+          >
+            {isResolved ? "Outage Resolved" : resolving ? "Resolving…" : "Resolve Outage"}
+          </button>
+        </div>
       </div>
 
       {error ? (
@@ -162,6 +206,97 @@ export default function OutageDetailsPage() {
           {error}
         </div>
       ) : null}
+
+      {/* FE-018: Inline edit panel */}
+      {editing && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle>Edit Outage</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="mb-1 block font-medium text-slate-700">Site Name</label>
+                <input
+                  className="w-full rounded-md border border-slate-200 px-3 py-2"
+                  value={editForm.site_name ?? ""}
+                  onChange={(e) => setEditForm((f) => ({ ...f, site_name: e.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block font-medium text-slate-700">Severity</label>
+                <select
+                  className="w-full rounded-md border border-slate-200 px-3 py-2"
+                  value={editForm.severity ?? ""}
+                  onChange={(e) => setEditForm((f) => ({ ...f, severity: e.target.value as Severity }))}
+                >
+                  {(["critical", "high", "medium", "low"] as Severity[]).map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block font-medium text-slate-700">Status</label>
+                <select
+                  className="w-full rounded-md border border-slate-200 px-3 py-2"
+                  value={editForm.status ?? ""}
+                  onChange={(e) => setEditForm((f) => ({ ...f, status: e.target.value as OutageStatus }))}
+                >
+                  <option value="open">open</option>
+                  <option value="resolved">resolved</option>
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block font-medium text-slate-700">Assigned To</label>
+                <input
+                  className="w-full rounded-md border border-slate-200 px-3 py-2"
+                  value={editForm.assigned_to ?? ""}
+                  onChange={(e) => setEditForm((f) => ({ ...f, assigned_to: e.target.value }))}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block font-medium text-slate-700">Description</label>
+              <textarea
+                className="w-full rounded-md border border-slate-200 px-3 py-2"
+                rows={3}
+                value={editForm.description ?? ""}
+                onChange={(e) => setEditForm((f) => ({ ...f, description: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label className="mb-1 block font-medium text-slate-700">
+                Affected Services (comma-separated)
+              </label>
+              <input
+                className="w-full rounded-md border border-slate-200 px-3 py-2"
+                value={(editForm.affected_services ?? []).join(", ")}
+                onChange={(e) =>
+                  setEditForm((f) => ({
+                    ...f,
+                    affected_services: e.target.value.split(",").map((s) => s.trim()).filter(Boolean),
+                  }))
+                }
+              />
+            </div>
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                onClick={() => setEditing(false)}
+                className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSaveEdit}
+                disabled={saving}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+              >
+                {saving ? "Saving…" : "Save Changes"}
+              </button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         <Card>
@@ -289,6 +424,31 @@ export default function OutageDetailsPage() {
               <span className="text-muted-foreground">Subscribers</span>
               <span className="font-medium">{outage.affected_subscribers ?? "Unknown"}</span>
             </div>
+          </CardContent>
+        </Card>
+
+        {/* FE-020: Outage history / timeline panel */}
+        <Card className="md:col-span-2">
+          <CardHeader className="pb-3">
+            <CardTitle>Outage History</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {timeline.length === 0 ? (
+              <p className="text-sm italic text-muted-foreground">No history events available yet.</p>
+            ) : (
+              <ol className="relative border-l border-slate-200 pl-6 space-y-4">
+                {timeline.map((event, i) => (
+                  <li key={i} className="relative">
+                    <span className="absolute -left-[1.35rem] top-1 h-3 w-3 rounded-full border-2 border-blue-500 bg-white" />
+                    <p className="text-sm font-medium text-slate-900">{event.label}</p>
+                    <p className="text-xs text-slate-500">{new Date(event.time).toLocaleString()}</p>
+                    {event.note && (
+                      <p className="mt-0.5 text-xs text-slate-400">{event.note}</p>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            )}
           </CardContent>
         </Card>
 

--- a/src/app/outages/components/outages-page-client.tsx
+++ b/src/app/outages/components/outages-page-client.tsx
@@ -92,11 +92,19 @@ export function OutagesPageClient() {
 
     return (
         <div className="space-y-6 p-6">
-            <div className="space-y-1">
-                <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Outages</h1>
-                <p className="text-sm text-slate-500">
-                    Review live incidents, filter by severity and status, and page through the active outage feed.
-                </p>
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Outages</h1>
+                    <p className="text-sm text-slate-500">
+                        Review live incidents, filter by severity and status, and page through the active outage feed.
+                    </p>
+                </div>
+                <Link
+                    href="/outages/new"
+                    className="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                >
+                    + New Outage
+                </Link>
             </div>
 
             <div className="flex justify-end">

--- a/src/app/outages/new/page.tsx
+++ b/src/app/outages/new/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createOutage } from "@/services/outages";
+import type { OutageCreate, Severity, OutageStatus } from "@/types/outages";
+
+function generateId() {
+  return `OUT-${Date.now()}`;
+}
+
+export default function NewOutagePage() {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [form, setForm] = useState({
+    site_name: "",
+    site_id: "",
+    severity: "medium" as Severity,
+    status: "open" as OutageStatus,
+    detected_at: new Date().toISOString().slice(0, 16),
+    description: "",
+    affected_services: "",
+    affected_subscribers: "",
+    assigned_to: "",
+  });
+
+  function set(field: string, value: string) {
+    setForm((f) => ({ ...f, [field]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.site_name.trim() || !form.description.trim()) {
+      setError("Site name and description are required.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    const payload: OutageCreate = {
+      id: generateId(),
+      site_name: form.site_name.trim(),
+      site_id: form.site_id.trim() || undefined,
+      severity: form.severity,
+      status: form.status,
+      detected_at: new Date(form.detected_at).toISOString(),
+      description: form.description.trim(),
+      affected_services: form.affected_services
+        ? form.affected_services.split(",").map((s) => s.trim()).filter(Boolean)
+        : [],
+      affected_subscribers: form.affected_subscribers
+        ? parseInt(form.affected_subscribers, 10)
+        : undefined,
+      assigned_to: form.assigned_to.trim() || undefined,
+    };
+
+    try {
+      const outage = await createOutage(payload);
+      router.push(`/outages/${outage.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create outage.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <div className="mb-6 flex items-center gap-4">
+        <button
+          onClick={() => router.push("/outages")}
+          className="text-sm text-slate-500 hover:text-slate-800"
+        >
+          ← Back to outages
+        </button>
+        <h1 className="text-2xl font-semibold text-slate-900">Create Outage</h1>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-5 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">
+              Site Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+              value={form.site_name}
+              onChange={(e) => set("site_name", e.target.value)}
+              placeholder="e.g. Lagos Node 1"
+              required
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Site ID</label>
+            <input
+              className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+              value={form.site_id}
+              onChange={(e) => set("site_id", e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Severity</label>
+            <select
+              className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+              value={form.severity}
+              onChange={(e) => set("severity", e.target.value)}
+            >
+              {(["critical", "high", "medium", "low"] as Severity[]).map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Status</label>
+            <select
+              className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+              value={form.status}
+              onChange={(e) => set("status", e.target.value)}
+            >
+              <option value="open">open</option>
+              <option value="resolved">resolved</option>
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-slate-700">Detected At</label>
+          <input
+            type="datetime-local"
+            className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+            value={form.detected_at}
+            onChange={(e) => set("detected_at", e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-slate-700">
+            Description <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+            rows={3}
+            value={form.description}
+            onChange={(e) => set("description", e.target.value)}
+            placeholder="Describe the outage…"
+            required
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-slate-700">
+            Affected Services
+          </label>
+          <input
+            className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+            value={form.affected_services}
+            onChange={(e) => set("affected_services", e.target.value)}
+            placeholder="Comma-separated, e.g. DNS, VoIP"
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">
+              Affected Subscribers
+            </label>
+            <input
+              type="number"
+              min={0}
+              className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+              value={form.affected_subscribers}
+              onChange={(e) => set("affected_subscribers", e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Assigned To</label>
+            <input
+              className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm"
+              value={form.assigned_to}
+              onChange={(e) => set("assigned_to", e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => router.push("/outages")}
+            className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+          >
+            {submitting ? "Creating…" : "Create Outage"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -692,6 +692,44 @@ export default function SettingsPage() {
           </div>
         </section>
       </div>
+
+      {/* FE-022: Wallet readiness guidance */}
+      {walletStatus && !walletStatus.usable && (
+        <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-amber-900">Wallet Not Ready — Next Steps</h2>
+          <p className="mt-1 text-sm text-amber-700">
+            Your wallet must be funded and have a trustline set up before payments can be processed.
+          </p>
+          <ul className="mt-4 space-y-3">
+            {!walletStatus.active && (
+              <li className="flex items-start gap-3 text-sm text-amber-800">
+                <span className="mt-0.5 h-5 w-5 shrink-0 rounded-full bg-amber-200 text-center text-xs font-bold leading-5 text-amber-900">1</span>
+                <span><strong>Activate your wallet.</strong> The wallet is currently inactive. Contact your administrator or re-link the wallet via the Wallet Status panel above.</span>
+              </li>
+            )}
+            {walletStatus.active && !walletStatus.funded && (
+              <li className="flex items-start gap-3 text-sm text-amber-800">
+                <span className="mt-0.5 h-5 w-5 shrink-0 rounded-full bg-amber-200 text-center text-xs font-bold leading-5 text-amber-900">2</span>
+                <span><strong>Fund your wallet.</strong> Send at least 1 XLM to <code className="rounded bg-amber-100 px-1 font-mono text-xs">{walletStatus.public_key}</code> on the Stellar network to activate the account.</span>
+              </li>
+            )}
+            {walletStatus.active && walletStatus.funded && !walletStatus.trustline_ready && (
+              <li className="flex items-start gap-3 text-sm text-amber-800">
+                <span className="mt-0.5 h-5 w-5 shrink-0 rounded-full bg-amber-200 text-center text-xs font-bold leading-5 text-amber-900">3</span>
+                <span><strong>Set up a trustline.</strong> Your wallet is funded but missing a trustline for the payment asset. Use the Stellar Laboratory or your wallet app to add a trustline for the required asset.</span>
+              </li>
+            )}
+          </ul>
+        </section>
+      )}
+
+      {walletStatus?.usable && (
+        <section className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 shadow-sm">
+          <p className="text-sm font-medium text-emerald-800">
+            ✓ Wallet is fully ready — funded, trustline active, and usable for payments.
+          </p>
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements all four demilade18-git issues.

### FE-017 — Outage creation form (#84)
- New route `/outages/new` with a full create form: site name, site ID, severity, status, detected-at datetime, description, affected services (comma-separated), affected subscribers, assigned-to
- Required fields validated before submission; success redirects to the new outage detail page; error state shown inline
- "+ New Outage" button added to the outages list header

### FE-018 — Outage edit workflow (#85)
- Edit button on the outage details page toggles an inline edit panel pre-filled with current values
- Editable fields: site name, severity, status, assigned-to, description, affected services
- Saves via `updateOutage`; updated values reflected immediately without breaking the resolve flow

### FE-020 — Outage timeline / history panel (#87)
- "Outage History" card added to the details page below the Impact card
- Vertical timeline derived from outage data: detected-at, SLA computed (with status + rating note), resolved-at
- Clean empty state when no events are available; does not regress SLA or payment sections

### FE-022 — Wallet readiness guidance (#89)
- Amber guidance panel shown in settings when `walletStatus.usable` is false
- Step-by-step next steps: activate wallet → fund with XLM → set up trustline; each step only shown when relevant
- Green confirmation banner shown when wallet is fully ready

## Tested
- `npm run build` passes, new `/outages/new` route appears in the route table

Closes #84
Closes #85
Closes #87
Closes #89