### PR TITLE
feat: FE-065/066/067/068 - React Query mutations, SLA contract alignment, dispute notes + filter

### DIFF
--- a/src/app/outages/[id]/page.tsx
+++ b/src/app/outages/[id]/page.tsx
@@ -1,106 +1,34 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useParams } from "next/navigation";
 
 import { ResolveOutageModal } from "@/features/outages/components/ResolveOutageModal";
+import { useOutage, useResolveOutage } from "@/features/outages/hooks/useOutageMutations";
 import { SLADisputesPanel } from "@/components/outages/SLADisputesPanel";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { Separator } from "@/components/ui/separator";
-import { getOutage, resolveOutage } from "@/services/outages";
-import type { Outage, OutageResolutionPayment } from "@/types/outages";
-
-function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : "Failed to load outage";
-}
+import type { OutageResolutionPayment } from "@/types/outages";
 
 export default function OutageDetailsPage() {
   const params = useParams<{ id: string }>();
-  const id = params?.id;
-  const [outage, setOutage] = useState<Outage | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [resolving, setResolving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const id = params?.id ?? "";
+
+  const { data: outage, isLoading, isError } = useOutage(id);
+  const resolveMutation = useResolveOutage(id);
+
   const [isResolveModalOpen, setIsResolveModalOpen] = useState(false);
   const [resolutionPayment, setResolutionPayment] = useState<OutageResolutionPayment | null>(null);
 
-  const isFetching = useRef(false);
-  const hasOutageRef = useRef(false);
-
-  useEffect(() => {
-    hasOutageRef.current = outage !== null;
-  }, [outage]);
-
-  useEffect(() => {
-    if (!id) {
-      return;
-    }
-
-    let isMounted = true;
-
-    const fetchOutage = async () => {
-      if (isFetching.current) {
-        return;
-      }
-      isFetching.current = true;
-
-      try {
-        const data = await getOutage(id);
-        if (isMounted) {
-          setOutage(data);
-          setError(null);
-        }
-      } catch (issue) {
-        if (isMounted && !hasOutageRef.current) {
-          setError(getErrorMessage(issue));
-        }
-      } finally {
-        isFetching.current = false;
-        if (isMounted) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOutage();
-
-    const intervalId =
-      outage?.status === "resolved" ? null : setInterval(() => void fetchOutage(), 15000);
-
-    return () => {
-      isMounted = false;
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-    };
-  }, [id, outage?.status]);
-
   async function handleResolve(mttrMinutes: number) {
-    if (!id) {
-      return;
-    }
-
-    setResolving(true);
-    setError(null);
-
-    try {
-      const updated = await resolveOutage(id, { mttr_minutes: mttrMinutes });
-      setOutage({
-        ...updated.outage,
-        sla_status: updated.sla,
-      });
-      setResolutionPayment(updated.payment);
-      setIsResolveModalOpen(false);
-    } catch (issue) {
-      setError(getErrorMessage(issue));
-    } finally {
-      setResolving(false);
-    }
+    const result = await resolveMutation.mutateAsync(mttrMinutes);
+    setResolutionPayment(result.payment);
+    setIsResolveModalOpen(false);
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <RouteLoadingState
         title="Loading outage details"
@@ -109,11 +37,11 @@ export default function OutageDetailsPage() {
     );
   }
 
-  if (error && !outage) {
+  if (isError) {
     return (
       <RouteErrorState
         title="Error loading outage"
-        description={error}
+        description="Failed to load outage"
         actionLabel="Reload page"
         onAction={() => window.location.reload()}
       />
@@ -146,22 +74,24 @@ export default function OutageDetailsPage() {
 
         <button
           onClick={() => setIsResolveModalOpen(true)}
-          disabled={isResolved || resolving}
+          disabled={isResolved || resolveMutation.isPending}
           className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
             isResolved
               ? "cursor-not-allowed bg-gray-100 text-gray-500"
               : "bg-blue-600 text-white hover:bg-blue-700"
           }`}
         >
-          {isResolved ? "Outage Resolved" : resolving ? "Resolving…" : "Resolve Outage"}
+          {isResolved ? "Outage Resolved" : resolveMutation.isPending ? "Resolving…" : "Resolve Outage"}
         </button>
       </div>
 
-      {error ? (
+      {resolveMutation.isError && (
         <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
-          {error}
+          {resolveMutation.error instanceof Error
+            ? resolveMutation.error.message
+            : "Failed to resolve outage"}
         </div>
-      ) : null}
+      )}
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         <Card>
@@ -302,15 +232,20 @@ export default function OutageDetailsPage() {
         severity={outage.severity}
         initialMttrMinutes={outage.sla_status?.mttr_minutes}
         isOpen={isResolveModalOpen}
-        isResolving={resolving}
-        error={error}
+        isResolving={resolveMutation.isPending}
+        error={
+          resolveMutation.isError
+            ? resolveMutation.error instanceof Error
+              ? resolveMutation.error.message
+              : "Failed to resolve outage"
+            : null
+        }
         onClose={() => {
-          if (!resolving) {
+          if (!resolveMutation.isPending) {
             setIsResolveModalOpen(false);
-            setError(null);
           }
         }}
-        onConfirmResolve={handleResolve}
+        onConfirmResolve={(mttr) => handleResolve(mttr)}
       />
     </div>
   );

--- a/src/components/outages/SLADisputesPanel.tsx
+++ b/src/components/outages/SLADisputesPanel.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { flagDispute, getDisputes, resolveDispute } from "@/services/sla";
-import type { SLADispute } from "@/types/sla";
+import type { DisputeStatus, SLADispute } from "@/types/sla";
+
+const PAGE_SIZE = 5;
 
 const statusVariant: Record<string, "outline" | "secondary" | "destructive" | "default"> = {
   open: "destructive",
@@ -22,49 +25,58 @@ interface Props {
 }
 
 export function SLADisputesPanel({ outageId, canResolve = false }: Props) {
-  const [disputes, setDisputes] = useState<SLADispute[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const qc = useQueryClient();
+
+  const [statusFilter, setStatusFilter] = useState<DisputeStatus | "">("");
+  const [page, setPage] = useState(1);
   const [reason, setReason] = useState("");
-  const [flagging, setFlagging] = useState(false);
-  const [resolvingId, setResolvingId] = useState<string | null>(null);
+  // resolution note state: keyed by disputeId
+  const [noteInputs, setNoteInputs] = useState<Record<string, string>>({});
 
-  useEffect(() => {
-    let isMounted = true;
-    setLoading(true);
-    getDisputes(outageId)
-      .then((data) => { if (isMounted) setDisputes(data); })
-      .catch(() => { if (isMounted) setError("Failed to load disputes."); })
-      .finally(() => { if (isMounted) setLoading(false); });
-    return () => { isMounted = false; };
-  }, [outageId]);
+  const queryKey = ["disputes", outageId, statusFilter, page];
 
-  async function handleFlag() {
-    if (!reason.trim()) return;
-    setFlagging(true);
-    setError(null);
-    try {
-      const dispute = await flagDispute(outageId, reason.trim());
-      setDisputes((prev) => [dispute, ...prev]);
+  const { data, isLoading, isError } = useQuery({
+    queryKey,
+    queryFn: () =>
+      getDisputes({
+        outage_id: outageId,
+        status: statusFilter || undefined,
+        page,
+        page_size: PAGE_SIZE,
+      }),
+  });
+
+  const disputes: SLADispute[] = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const flagMutation = useMutation({
+    mutationFn: () => flagDispute({ outage_id: outageId, reason: reason.trim() }),
+    onSuccess: () => {
       setReason("");
-    } catch {
-      setError("Failed to flag dispute.");
-    } finally {
-      setFlagging(false);
-    }
-  }
+      void qc.invalidateQueries({ queryKey: ["disputes", outageId] });
+    },
+  });
 
-  async function handleAction(disputeId: string, action: "resolve" | "reject") {
-    setResolvingId(disputeId);
-    setError(null);
-    try {
-      const updated = await resolveDispute(disputeId, action);
-      setDisputes((prev) => prev.map((d) => (d.id === disputeId ? updated : d)));
-    } catch {
-      setError(`Failed to ${action} dispute.`);
-    } finally {
-      setResolvingId(null);
-    }
+  const resolveMutation = useMutation({
+    mutationFn: ({
+      disputeId,
+      action,
+      note,
+    }: {
+      disputeId: string;
+      action: "resolve" | "reject";
+      note?: string;
+    }) => resolveDispute(disputeId, { action, resolution_note: note }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["disputes", outageId] });
+    },
+  });
+
+  function handleAction(dispute: SLADispute, action: "resolve" | "reject") {
+    const note = noteInputs[dispute.id]?.trim();
+    resolveMutation.mutate({ disputeId: dispute.id, action, note });
+    setNoteInputs((prev) => ({ ...prev, [dispute.id]: "" }));
   }
 
   return (
@@ -80,25 +92,47 @@ export function SLADisputesPanel({ outageId, canResolve = false }: Props) {
             placeholder="Reason for dispute…"
             value={reason}
             onChange={(e) => setReason(e.target.value)}
-            disabled={flagging}
+            disabled={flagMutation.isPending}
           />
           <Button
             variant="outline"
-            disabled={!reason.trim() || flagging}
-            onClick={() => void handleFlag()}
+            disabled={!reason.trim() || flagMutation.isPending}
+            onClick={() => flagMutation.mutate()}
           >
-            {flagging ? "Flagging…" : "Flag dispute"}
+            {flagMutation.isPending ? "Flagging…" : "Flag dispute"}
           </Button>
         </div>
 
-        {error && (
-          <p className="text-xs text-red-600">{error}</p>
+        {flagMutation.isError && (
+          <p className="text-xs text-red-600">Failed to flag dispute.</p>
+        )}
+        {resolveMutation.isError && (
+          <p className="text-xs text-red-600">Failed to update dispute.</p>
         )}
 
-        {loading && <p className="text-slate-400 italic">Loading disputes…</p>}
+        {/* Status filter */}
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-slate-500">Filter:</span>
+          {(["", "open", "under_review", "resolved", "rejected"] as const).map((s) => (
+            <button
+              key={s}
+              onClick={() => { setStatusFilter(s); setPage(1); }}
+              className={`rounded-full border px-3 py-0.5 text-xs capitalize transition-colors ${
+                statusFilter === s
+                  ? "border-slate-700 bg-slate-700 text-white"
+                  : "border-slate-200 bg-slate-50 text-slate-600 hover:bg-slate-100"
+              }`}
+            >
+              {s === "" ? "All" : s.replace("_", " ")}
+            </button>
+          ))}
+        </div>
 
-        {!loading && disputes.length === 0 && (
-          <p className="italic text-slate-400">No disputes filed for this outage.</p>
+        {isLoading && <p className="italic text-slate-400">Loading disputes…</p>}
+        {isError && <p className="text-xs text-red-600">Failed to load disputes.</p>}
+
+        {!isLoading && disputes.length === 0 && (
+          <p className="italic text-slate-400">No disputes found.</p>
         )}
 
         {disputes.map((dispute, i) => (
@@ -115,31 +149,69 @@ export function SLADisputesPanel({ outageId, canResolve = false }: Props) {
               </div>
               <p className="text-slate-700">{dispute.reason}</p>
               {dispute.resolution_note && (
-                <p className="text-xs text-slate-500 italic">Note: {dispute.resolution_note}</p>
+                <p className="text-xs italic text-slate-500">Note: {dispute.resolution_note}</p>
               )}
               {canResolve && dispute.status === "open" && (
-                <div className="flex gap-2 pt-1">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={resolvingId === dispute.id}
-                    onClick={() => void handleAction(dispute.id, "resolve")}
-                  >
-                    Resolve
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={resolvingId === dispute.id}
-                    onClick={() => void handleAction(dispute.id, "reject")}
-                  >
-                    Reject
-                  </Button>
+                <div className="space-y-2 pt-1">
+                  <input
+                    className="w-full rounded-md border border-slate-200 px-3 py-1.5 text-xs"
+                    placeholder="Resolution note (optional)…"
+                    value={noteInputs[dispute.id] ?? ""}
+                    onChange={(e) =>
+                      setNoteInputs((prev) => ({ ...prev, [dispute.id]: e.target.value }))
+                    }
+                    disabled={resolveMutation.isPending}
+                  />
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={resolveMutation.isPending}
+                      onClick={() => handleAction(dispute, "resolve")}
+                    >
+                      Resolve
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={resolveMutation.isPending}
+                      onClick={() => handleAction(dispute, "reject")}
+                    >
+                      Reject
+                    </Button>
+                  </div>
                 </div>
               )}
             </div>
           </div>
         ))}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between border-t border-slate-100 pt-3 text-xs text-slate-500">
+            <span>
+              Page {page} of {totalPages} ({total} total)
+            </span>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/features/outages/hooks/useOutageMutations.ts
+++ b/src/features/outages/hooks/useOutageMutations.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { deleteOutage, getOutage, resolveOutage } from "@/services/outages";
+
+export const outageKeys = {
+  all: ["outages"] as const,
+  detail: (id: string) => ["outages", id] as const,
+};
+
+export function useOutage(id: string) {
+  return useQuery({
+    queryKey: outageKeys.detail(id),
+    queryFn: () => getOutage(id),
+    enabled: !!id,
+    refetchInterval: (query) =>
+      query.state.data?.status === "resolved" ? false : 15_000,
+  });
+}
+
+export function useResolveOutage(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (mttrMinutes: number) =>
+      resolveOutage(id, { mttr_minutes: mttrMinutes }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: outageKeys.detail(id) });
+      void qc.invalidateQueries({ queryKey: outageKeys.all });
+    },
+  });
+}
+
+export function useDeleteOutage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteOutage(id),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: outageKeys.all });
+    },
+  });
+}

--- a/src/services/sla.ts
+++ b/src/services/sla.ts
@@ -1,14 +1,19 @@
 import { api } from "@/lib/api";
-import type { SLAResult, SLADispute } from "@/types/sla";
+import type {
+  DisputeListParams,
+  FlagDisputePayload,
+  PaginatedDisputes,
+  ResolveDisputePayload,
+  SLADispute,
+  SLAResult,
+} from "@/types/sla";
 
 export async function calculateSLA(params: {
   outage_id: string;
   severity: string;
   mttr_minutes: number;
 }): Promise<SLAResult> {
-  const res = await api.get<SLAResult>("/sla/calculate", {
-    params,
-  });
+  const res = await api.get<SLAResult>("/sla/calculate", { params });
   return res.data;
 }
 
@@ -20,17 +25,20 @@ export async function previewSLA(params: {
   return res.data;
 }
 
-export async function getDisputes(outageId: string): Promise<SLADispute[]> {
-  const res = await api.get<SLADispute[]>(`/sla/disputes`, { params: { outage_id: outageId } });
+export async function getDisputes(params: DisputeListParams): Promise<PaginatedDisputes> {
+  const res = await api.get<PaginatedDisputes>("/sla/disputes", { params });
   return res.data;
 }
 
-export async function flagDispute(outageId: string, reason: string): Promise<SLADispute> {
-  const res = await api.post<SLADispute>(`/sla/disputes`, { outage_id: outageId, reason });
+export async function flagDispute(payload: FlagDisputePayload): Promise<SLADispute> {
+  const res = await api.post<SLADispute>("/sla/disputes", payload);
   return res.data;
 }
 
-export async function resolveDispute(disputeId: string, action: "resolve" | "reject", note?: string): Promise<SLADispute> {
-  const res = await api.patch<SLADispute>(`/sla/disputes/${disputeId}`, { action, resolution_note: note });
+export async function resolveDispute(
+  disputeId: string,
+  payload: ResolveDisputePayload,
+): Promise<SLADispute> {
+  const res = await api.patch<SLADispute>(`/sla/disputes/${disputeId}`, payload);
   return res.data;
 }

--- a/src/types/sla.ts
+++ b/src/types/sla.ts
@@ -20,3 +20,27 @@ export interface SLADispute {
   resolved_at?: string | null;
   resolution_note?: string | null;
 }
+
+export interface FlagDisputePayload {
+  outage_id: string;
+  reason: string;
+}
+
+export interface ResolveDisputePayload {
+  action: "resolve" | "reject";
+  resolution_note?: string;
+}
+
+export interface DisputeListParams {
+  outage_id: string;
+  status?: DisputeStatus;
+  page?: number;
+  page_size?: number;
+}
+
+export interface PaginatedDisputes {
+  items: SLADispute[];
+  total: number;
+  page: number;
+  page_size: number;
+}


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to JoeX17 in a single cohesive change across the outage detail and SLA disputes surface.

### FE-065 — React Query mutation and invalidation strategy for outage actions
- Added `src/features/outages/hooks/useOutageMutations.ts` with `useOutage`, `useResolveOutage`, and `useDeleteOutage` hooks
- Centralized query key namespace via `outageKeys` — all mutations invalidate the correct list and detail queries
- Rewrote `src/app/outages/[id]/page.tsx` to use these hooks; removed raw `useEffect`/`useState` data-fetching

### FE-066 — SLA dispute API contract alignment
- Added `FlagDisputePayload`, `ResolveDisputePayload`, `DisputeListParams`, and `PaginatedDisputes` types to `src/types/sla.ts`
- Updated `src/services/sla.ts` to accept typed payloads and return `PaginatedDisputes` from `getDisputes`

### FE-067 — Dispute resolution note workflow
- `SLADisputesPanel` now renders a per-dispute note input for open disputes
- Note is validated (trimmed) and sent as `resolution_note` in the resolve/reject payload

### FE-068 — Dispute status filter and pagination
- Status filter buttons (All / open / under_review / resolved / rejected) reset page on change
- Pagination controls appear when `totalPages > 1`; loading and empty states remain consistent

## Tested
- `npm run build` passes with no TypeScript errors

Closes #109
Closes #110
Closes #111
Closes #112