### PR TITLE
feat: payments filters, outage links, retry/reconcile, sorting and density

### DIFF
--- a/src/components/payments/payment-detail-drawer.tsx
+++ b/src/components/payments/payment-detail-drawer.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
 import { RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
-import { fetchPayment } from "@/services/paymentService";
+import { fetchPayment, retryPayment, reconcilePayment } from "@/services/paymentService";
 import type { Payment } from "@/types/payment";
 
 const statusStyles: Record<string, string> = {
@@ -22,15 +23,14 @@ export function PaymentDetailDrawer({ paymentId, onClose }: Props) {
   const [payment, setPayment] = useState<Payment | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [actionState, setActionState] = useState<{ type: "retry" | "reconcile"; status: "loading" | "success" | "error"; message?: string } | null>(null);
 
   useEffect(() => {
-    if (!paymentId) {
-      setPayment(null);
-      return;
-    }
+    if (!paymentId) { setPayment(null); return; }
     let isMounted = true;
     setLoading(true);
     setError(null);
+    setActionState(null);
     fetchPayment(paymentId)
       .then((data) => { if (isMounted) setPayment(data); })
       .catch(() => { if (isMounted) setError("Failed to load payment details."); })
@@ -38,37 +38,37 @@ export function PaymentDetailDrawer({ paymentId, onClose }: Props) {
     return () => { isMounted = false; };
   }, [paymentId]);
 
+  async function handleAction(type: "retry" | "reconcile") {
+    if (!payment) return;
+    setActionState({ type, status: "loading" });
+    try {
+      const updated = type === "retry"
+        ? await retryPayment(payment.id)
+        : await reconcilePayment(payment.id);
+      setPayment(updated);
+      setActionState({ type, status: "success", message: `${type === "retry" ? "Retry" : "Reconciliation"} succeeded.` });
+    } catch (err) {
+      setActionState({
+        type,
+        status: "error",
+        message: err instanceof Error ? err.message : `${type} failed. Please try again.`,
+      });
+    }
+  }
+
   if (!paymentId) return null;
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-40 bg-black/30"
-        onClick={onClose}
-        aria-hidden="true"
-      />
-
-      {/* Drawer */}
+      <div className="fixed inset-0 z-40 bg-black/30" onClick={onClose} aria-hidden="true" />
       <aside className="fixed right-0 top-0 z-50 flex h-full w-full max-w-md flex-col bg-white shadow-xl">
         <div className="flex items-center justify-between border-b px-6 py-4">
           <h2 className="text-lg font-semibold text-slate-900">Payment Details</h2>
-          <button
-            onClick={onClose}
-            className="text-slate-400 hover:text-slate-600 text-xl leading-none"
-            aria-label="Close drawer"
-          >
-            ×
-          </button>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-600 text-xl leading-none" aria-label="Close drawer">×</button>
         </div>
 
         <div className="flex-1 overflow-y-auto p-6">
-          {loading && (
-            <RouteLoadingState
-              title="Loading payment"
-              description="Fetching transaction metadata."
-            />
-          )}
+          {loading && <RouteLoadingState title="Loading payment" description="Fetching transaction metadata." />}
           {error && (
             <RouteErrorState
               title="Error"
@@ -85,41 +85,86 @@ export function PaymentDetailDrawer({ paymentId, onClose }: Props) {
             />
           )}
           {!loading && !error && payment && (
-            <dl className="space-y-4 text-sm">
-              <Row label="Payment ID" value={payment.id} mono />
-              <Row label="Outage ID" value={payment.outage_id} mono />
-              <Row
-                label="Type"
-                value={
-                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${payment.type === "penalty" ? "bg-red-100 text-red-700" : "bg-blue-100 text-blue-700"}`}>
-                    {payment.type}
-                  </span>
-                }
-              />
-              <Row
-                label="Amount"
-                value={
-                  <span className={`font-semibold ${payment.type === "penalty" ? "text-red-600" : "text-green-600"}`}>
-                    {payment.type === "penalty" ? "-" : "+"}${payment.amount.toLocaleString()} {payment.asset_code}
-                  </span>
-                }
-              />
-              <Row
-                label="Status"
-                value={
-                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${statusStyles[payment.status] ?? "bg-gray-100 text-gray-500"}`}>
-                    {payment.status}
-                  </span>
-                }
-              />
-              <Row label="From" value={payment.from_address} mono />
-              <Row label="To" value={payment.to_address} mono />
-              <Row label="Transaction Hash" value={payment.transaction_hash} mono />
-              <Row label="Created" value={new Date(payment.created_at).toLocaleString()} />
-              {payment.confirmed_at && (
-                <Row label="Confirmed" value={new Date(payment.confirmed_at).toLocaleString()} />
-              )}
-            </dl>
+            <div className="space-y-6">
+              <dl className="space-y-4 text-sm">
+                <Row label="Payment ID" value={payment.id} mono />
+                {/* FE-070: outage link in drawer */}
+                <Row
+                  label="Outage"
+                  value={
+                    payment.outage_id ? (
+                      <Link href={`/outages/${payment.outage_id}`} className="font-mono text-xs text-blue-600 hover:underline underline-offset-2">
+                        {payment.outage_id}
+                      </Link>
+                    ) : (
+                      <span className="italic text-slate-400">No linked outage</span>
+                    )
+                  }
+                />
+                <Row
+                  label="Type"
+                  value={
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${payment.type === "penalty" ? "bg-red-100 text-red-700" : "bg-blue-100 text-blue-700"}`}>
+                      {payment.type}
+                    </span>
+                  }
+                />
+                <Row
+                  label="Amount"
+                  value={
+                    <span className={`font-semibold ${payment.type === "penalty" ? "text-red-600" : "text-green-600"}`}>
+                      {payment.type === "penalty" ? "-" : "+"}${payment.amount.toLocaleString()} {payment.asset_code}
+                    </span>
+                  }
+                />
+                <Row
+                  label="Status"
+                  value={
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${statusStyles[payment.status] ?? "bg-gray-100 text-gray-500"}`}>
+                      {payment.status}
+                    </span>
+                  }
+                />
+                <Row label="From" value={payment.from_address} mono />
+                <Row label="To" value={payment.to_address} mono />
+                <Row label="Transaction Hash" value={payment.transaction_hash} mono />
+                <Row label="Created" value={new Date(payment.created_at).toLocaleString()} />
+                {payment.confirmed_at && (
+                  <Row label="Confirmed" value={new Date(payment.confirmed_at).toLocaleString()} />
+                )}
+              </dl>
+
+              {/* FE-071: retry + reconcile controls */}
+              <div className="space-y-3 border-t border-slate-100 pt-4">
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Actions</p>
+                {actionState?.status === "success" && (
+                  <div className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+                    {actionState.message}
+                  </div>
+                )}
+                {actionState?.status === "error" && (
+                  <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+                    {actionState.message}
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleAction("retry")}
+                    disabled={actionState?.status === "loading"}
+                    className="flex-1 rounded-md border border-blue-200 px-3 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                  >
+                    {actionState?.type === "retry" && actionState.status === "loading" ? "Retrying…" : "Retry Payment"}
+                  </button>
+                  <button
+                    onClick={() => handleAction("reconcile")}
+                    disabled={actionState?.status === "loading"}
+                    className="flex-1 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                  >
+                    {actionState?.type === "reconcile" && actionState.status === "loading" ? "Reconciling…" : "Reconcile"}
+                  </button>
+                </div>
+              </div>
+            </div>
           )}
         </div>
       </aside>

--- a/src/components/payments/payments-view.tsx
+++ b/src/components/payments/payments-view.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 
 import { PaymentDetailDrawer } from "@/components/payments/payment-detail-drawer";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { fetchPayments } from "@/services/paymentService";
 import type { PaginatedPayments, Payment } from "@/types/payment";
 
-const PER_PAGE = 10;
+type SortKey = "created_at" | "amount" | "status";
+type SortDir = "asc" | "desc";
+type Density = "default" | "compact";
 
 const statusStyles: Record<string, string> = {
   completed: "bg-green-100 text-green-700",
@@ -24,177 +27,240 @@ const typeStyles: Record<string, string> = {
 export default function PaymentsView() {
   const [data, setData] = useState<PaginatedPayments | null>(null);
   const [page, setPage] = useState(1);
+  const [perPage] = useState(10);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedPaymentId, setSelectedPaymentId] = useState<string | null>(null);
-  const requestKey = useMemo(() => `${page}:${PER_PAGE}`, [page]);
+
+  // FE-069: filter state
+  const [statusFilter, setStatusFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  // FE-072: sort + density
+  const [sortKey, setSortKey] = useState<SortKey>("created_at");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [density, setDensity] = useState<Density>("default");
+
+  const requestKey = useMemo(
+    () => `${page}:${perPage}:${statusFilter}:${typeFilter}:${dateFrom}:${dateTo}`,
+    [page, perPage, statusFilter, typeFilter, dateFrom, dateTo]
+  );
 
   useEffect(() => {
     let isMounted = true;
-
-    fetchPayments(page, PER_PAGE)
-      .then((response) => {
-        if (isMounted) {
-          setData(response);
-          setError(null);
-        }
-      })
-      .catch(() => {
-        if (isMounted) {
-          setError("Failed to load payments.");
-        }
-      })
-      .finally(() => {
-        if (isMounted) {
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [requestKey, page]);
-
-  function goToPreviousPage() {
     setLoading(true);
-    setError(null);
-    setPage((currentPage) => Math.max(1, currentPage - 1));
+    fetchPayments({
+      page,
+      page_size: perPage,
+      status: statusFilter || undefined,
+      type: typeFilter || undefined,
+      date_from: dateFrom || undefined,
+      date_to: dateTo || undefined,
+    })
+      .then((response) => { if (isMounted) { setData(response); setError(null); } })
+      .catch(() => { if (isMounted) setError("Failed to load payments."); })
+      .finally(() => { if (isMounted) setLoading(false); });
+    return () => { isMounted = false; };
+  }, [requestKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // FE-072: client-side sort
+  const sortedItems = useMemo(() => {
+    if (!data) return [];
+    return [...data.items].sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === "created_at") {
+        cmp = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+      } else if (sortKey === "amount") {
+        cmp = a.amount - b.amount;
+      } else if (sortKey === "status") {
+        cmp = a.status.localeCompare(b.status);
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+  }, [data, sortKey, sortDir]);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
   }
 
-  function goToNextPage() {
-    if (!data) {
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    setPage((currentPage) => Math.min(Math.ceil(data.total / data.page_size), currentPage + 1));
+  function SortIndicator({ col }: { col: SortKey }) {
+    if (sortKey !== col) return <span className="ml-1 text-gray-300">↕</span>;
+    return <span className="ml-1">{sortDir === "asc" ? "↑" : "↓"}</span>;
   }
 
-  function renderBody() {
-    if (loading) {
-      return (
-        <tr>
-          <td colSpan={6} className="p-0">
-            <RouteLoadingState
-              title="Loading payments"
-              description="Retrieving the latest reward and penalty records."
-            />
-          </td>
-        </tr>
-      );
-    }
-
-    if (error) {
-      return (
-        <tr>
-          <td colSpan={6} className="p-0">
-            <RouteErrorState
-              title="Payments unavailable"
-              description={error}
-              actionLabel="Reload page"
-              onAction={() => window.location.reload()}
-            />
-          </td>
-        </tr>
-      );
-    }
-
-    if (!data || data.items.length === 0) {
-      return (
-        <tr>
-          <td colSpan={6} className="p-0">
-            <RouteEmptyState
-              title="No payments yet"
-              description="Resolved outages with financial outcomes will appear here."
-            />
-          </td>
-        </tr>
-      );
-    }
-
-    return data.items.map((payment: Payment) => (
-      <tr
-        key={payment.id}
-        className="border-t transition-colors hover:bg-gray-50 cursor-pointer"
-        onClick={() => setSelectedPaymentId(payment.id)}
-      >
-        <td className="px-4 py-3 text-sm font-mono text-gray-700">{payment.outage_id}</td>
-        <td className="px-4 py-3">
-          <span
-            className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${typeStyles[payment.type]}`}
-          >
-            {payment.type}
-          </span>
-        </td>
-        <td
-          className={`px-4 py-3 text-sm font-semibold ${
-            payment.type === "penalty" ? "text-red-600" : "text-green-600"
-          }`}
-        >
-          {payment.type === "penalty" ? "-" : "+"}$
-          {payment.amount.toLocaleString()}
-        </td>
-        <td className="px-4 py-3 text-sm text-gray-600">
-          {new Date(payment.created_at).toLocaleDateString()}
-        </td>
-        <td className="px-4 py-3 text-xs font-mono text-gray-500">{payment.asset_code}</td>
-        <td className="px-4 py-3">
-          <span
-            className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${
-              statusStyles[payment.status] ?? "bg-gray-100 text-gray-500"
-            }`}
-          >
-            {payment.status}
-          </span>
-        </td>
-      </tr>
-    ));
-  }
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / perPage)) : 1;
+  const cell = density === "compact" ? "px-3 py-1.5 text-xs" : "px-4 py-3 text-sm";
 
   return (
     <div className="space-y-4 p-6">
-      <h1 className="text-2xl font-bold text-gray-800">Payments</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-800">Payments</h1>
+        {/* FE-072: density toggle */}
+        <div className="flex items-center gap-1 text-xs text-slate-600">
+          <span className="font-medium">Density:</span>
+          {(["default", "compact"] as Density[]).map((d) => (
+            <button
+              key={d}
+              onClick={() => setDensity(d)}
+              className={`rounded px-2 py-0.5 capitalize border ${density === d ? "bg-slate-800 text-white border-slate-800" : "border-slate-200 hover:bg-slate-100"}`}
+            >
+              {d}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* FE-069: filter bar */}
+      <div className="grid grid-cols-2 gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
+        <label className="space-y-1 text-xs">
+          <span className="font-medium text-slate-600">Status</span>
+          <select
+            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
+            value={statusFilter}
+            onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
+          >
+            <option value="">All</option>
+            <option value="pending">Pending</option>
+            <option value="completed">Completed</option>
+            <option value="confirmed">Confirmed</option>
+            <option value="failed">Failed</option>
+          </select>
+        </label>
+        <label className="space-y-1 text-xs">
+          <span className="font-medium text-slate-600">Type</span>
+          <select
+            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
+            value={typeFilter}
+            onChange={(e) => { setTypeFilter(e.target.value); setPage(1); }}
+          >
+            <option value="">All</option>
+            <option value="reward">Reward</option>
+            <option value="penalty">Penalty</option>
+          </select>
+        </label>
+        <label className="space-y-1 text-xs">
+          <span className="font-medium text-slate-600">From</span>
+          <input
+            type="date"
+            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
+            value={dateFrom}
+            onChange={(e) => { setDateFrom(e.target.value); setPage(1); }}
+          />
+        </label>
+        <label className="space-y-1 text-xs">
+          <span className="font-medium text-slate-600">To</span>
+          <input
+            type="date"
+            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
+            value={dateTo}
+            onChange={(e) => { setDateTo(e.target.value); setPage(1); }}
+          />
+        </label>
+      </div>
+
       <div className="overflow-hidden rounded-xl bg-white shadow-sm">
         <table className="w-full text-left">
           <thead className="bg-gray-50">
             <tr>
-              {["Outage ID", "Type", "Amount", "Date", "Asset", "Status"].map((column) => (
-                <th
-                  key={column}
-                  className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500"
-                >
-                  {column}
-                </th>
-              ))}
+              {/* FE-070: Outage ID column is now a link */}
+              <th className={`${cell} text-xs font-semibold uppercase tracking-wide text-gray-500`}>Outage</th>
+              <th className={`${cell} text-xs font-semibold uppercase tracking-wide text-gray-500`}>Type</th>
+              {/* FE-072: sortable Amount */}
+              <th
+                className={`${cell} text-xs font-semibold uppercase tracking-wide text-gray-500 cursor-pointer select-none`}
+                onClick={() => toggleSort("amount")}
+              >
+                Amount <SortIndicator col="amount" />
+              </th>
+              {/* FE-072: sortable Date */}
+              <th
+                className={`${cell} text-xs font-semibold uppercase tracking-wide text-gray-500 cursor-pointer select-none`}
+                onClick={() => toggleSort("created_at")}
+              >
+                Date <SortIndicator col="created_at" />
+              </th>
+              <th className={`${cell} text-xs font-semibold uppercase tracking-wide text-gray-500`}>Asset</th>
+              {/* FE-072: sortable Status */}
+              <th
+                className={`${cell} text-xs font-semibold uppercase tracking-wide text-gray-500 cursor-pointer select-none`}
+                onClick={() => toggleSort("status")}
+              >
+                Status <SortIndicator col="status" />
+              </th>
             </tr>
           </thead>
-          <tbody>{renderBody()}</tbody>
+          <tbody>
+            {loading ? (
+              <tr><td colSpan={6} className="p-0">
+                <RouteLoadingState title="Loading payments" description="Retrieving the latest reward and penalty records." />
+              </td></tr>
+            ) : error ? (
+              <tr><td colSpan={6} className="p-0">
+                <RouteErrorState title="Payments unavailable" description={error} actionLabel="Reload page" onAction={() => window.location.reload()} />
+              </td></tr>
+            ) : sortedItems.length === 0 ? (
+              <tr><td colSpan={6} className="p-0">
+                <RouteEmptyState title="No payments found" description="Try adjusting your filters." />
+              </td></tr>
+            ) : sortedItems.map((payment: Payment) => (
+              <tr
+                key={payment.id}
+                className="border-t transition-colors hover:bg-gray-50 cursor-pointer"
+                onClick={() => setSelectedPaymentId(payment.id)}
+              >
+                {/* FE-070: outage link in table */}
+                <td className={`${cell} font-mono text-gray-700`}>
+                  {payment.outage_id ? (
+                    <Link
+                      href={`/outages/${payment.outage_id}`}
+                      className="text-blue-600 hover:underline underline-offset-2"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {payment.outage_id}
+                    </Link>
+                  ) : (
+                    <span className="italic text-gray-400">—</span>
+                  )}
+                </td>
+                <td className={cell}>
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${typeStyles[payment.type]}`}>
+                    {payment.type}
+                  </span>
+                </td>
+                <td className={`${cell} font-semibold ${payment.type === "penalty" ? "text-red-600" : "text-green-600"}`}>
+                  {payment.type === "penalty" ? "-" : "+"}${payment.amount.toLocaleString()}
+                </td>
+                <td className={`${cell} text-gray-600`}>
+                  {new Date(payment.created_at).toLocaleDateString()}
+                </td>
+                <td className={`${cell} font-mono text-gray-500`}>{payment.asset_code}</td>
+                <td className={cell}>
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${statusStyles[payment.status] ?? "bg-gray-100 text-gray-500"}`}>
+                    {payment.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
         </table>
       </div>
 
-      {data && Math.ceil(data.total / data.page_size) > 1 ? (
+      {data && totalPages > 1 && (
         <div className="flex items-center justify-between text-sm text-gray-500">
-          <span>
-            Page {data.page} of {Math.ceil(data.total / data.page_size)} - {data.total} total
-          </span>
+          <span>Page {page} of {totalPages} — {data.total} total</span>
           <div className="flex gap-2">
-            <button
-              onClick={goToPreviousPage}
-              disabled={page === 1}
-              className="rounded-lg border px-3 py-1.5 transition-colors hover:bg-gray-100 disabled:opacity-40"
-            >
-              Previous
-            </button>
-            <button
-              onClick={goToNextPage}
-              disabled={page === Math.ceil(data.total / data.page_size)}
-              className="rounded-lg border px-3 py-1.5 transition-colors hover:bg-gray-100 disabled:opacity-40"
-            >
-              Next
-            </button>
+            <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1} className="rounded-lg border px-3 py-1.5 transition-colors hover:bg-gray-100 disabled:opacity-40">Previous</button>
+            <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="rounded-lg border px-3 py-1.5 transition-colors hover:bg-gray-100 disabled:opacity-40">Next</button>
           </div>
         </div>
-      ) : null}
+      )}
 
       <PaymentDetailDrawer
         paymentId={selectedPaymentId}

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -1,17 +1,36 @@
 import { api } from "@/lib/api";
 import { PaginatedPayments, Payment } from "../types/payment";
 
+export interface PaymentFilters {
+  page?: number;
+  page_size?: number;
+  status?: string;
+  type?: string;
+  date_from?: string;
+  date_to?: string;
+}
+
 export const fetchPayments = async (
-  page: number = 1,
-  perPage: number = 10
+  filters: PaymentFilters = {}
 ): Promise<PaginatedPayments> => {
+  const { page = 1, page_size = 10, ...rest } = filters;
   const response = await api.get<PaginatedPayments>("/payments", {
-    params: { page, page_size: perPage },
+    params: { page, page_size, ...rest },
   });
   return response.data;
 };
 
 export const fetchPayment = async (id: string): Promise<Payment> => {
   const response = await api.get<Payment>(`/payments/${id}`);
+  return response.data;
+};
+
+export const retryPayment = async (id: string): Promise<Payment> => {
+  const response = await api.post<Payment>(`/payments/${id}/retry`);
+  return response.data;
+};
+
+export const reconcilePayment = async (id: string): Promise<Payment> => {
+  const response = await api.post<Payment>(`/payments/${id}/reconcile`);
   return response.data;
 };


### PR DESCRIPTION
## Summary

Implements four issues assigned to @thommyy7.

### FE-069 — Date-range and status filters (#113)
- `fetchPayments` now accepts `status`, `type`, `date_from`, `date_to` query params forwarded to the backend
- Filter bar added above the payments table with dropdowns for status/type and date pickers for the range
- Filter changes reset pagination to page 1

### FE-070 — Outage-to-payment linking (#114)
- Outage ID column in the payments table renders as a `/outages/[id]` link; click does not open the drawer
- Drawer shows the outage ID as a navigable link; falls back to an explicit empty state when `outage_id` is absent

### FE-071 — Payment retry and reconciliation controls (#115)
- `retryPayment` and `reconcilePayment` added to `paymentService.ts` (POST `/payments/:id/retry` and `/payments/:id/reconcile`)
- Drawer renders **Retry Payment** and **Reconcile** buttons; both show loading state while in-flight
- Success updates the displayed payment record; errors surface inline without closing the drawer

### FE-072 — Sorting and density controls (#116)
- Amount, Date, and Status columns are sortable (click header to toggle asc/desc); active sort shown with ↑/↓ indicator
- Compact/default density toggle in the page header; adjusts cell padding across the table

## Testing
- `npm run build` passes with zero errors

Closes #113
Closes #114
Closes #115
Closes #116