### PR TITLE
feat: FE-073–076 payments export, dashboard filters, chart drilldowns

### DIFF
--- a/src/components/dashboard/PenaltiesRewardsChart.tsx
+++ b/src/components/dashboard/PenaltiesRewardsChart.tsx
@@ -2,13 +2,16 @@ import { TrendPoint } from "../../types/dashboard";
 
 interface PenaltiesRewardsChartProps {
   data: TrendPoint[];
+  onPenaltyClick?: (point: TrendPoint) => void;
+  onRewardClick?: (point: TrendPoint) => void;
 }
 
-const formatCurrency = (value: number) =>
-  `$${value.toLocaleString()}`;
+const formatCurrency = (value: number) => `$${value.toLocaleString()}`;
 
 const PenaltiesRewardsChart: React.FC<PenaltiesRewardsChartProps> = ({
   data,
+  onPenaltyClick,
+  onRewardClick,
 }) => {
   return (
     <div className="rounded-xl bg-white p-5 shadow-sm">
@@ -25,12 +28,18 @@ const PenaltiesRewardsChart: React.FC<PenaltiesRewardsChartProps> = ({
               className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 rounded-lg border border-gray-100 p-3"
             >
               <span className="text-sm font-medium text-gray-700">{point.period}</span>
-              <span className="rounded-full bg-red-50 px-3 py-1 text-xs font-semibold text-red-600">
+              <button
+                onClick={() => onPenaltyClick?.(point)}
+                className={`rounded-full bg-red-50 px-3 py-1 text-xs font-semibold text-red-600 ${onPenaltyClick ? "hover:bg-red-100 transition-colors cursor-pointer" : "cursor-default"}`}
+              >
                 Penalties: {formatCurrency(point.penalties)}
-              </span>
-              <span className="rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-600">
+              </button>
+              <button
+                onClick={() => onRewardClick?.(point)}
+                className={`rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-600 ${onRewardClick ? "hover:bg-green-100 transition-colors cursor-pointer" : "cursor-default"}`}
+              >
                 Rewards: {formatCurrency(point.rewards)}
-              </span>
+              </button>
             </div>
           ))
         )}

--- a/src/components/dashboard/SLATrendChart.tsx
+++ b/src/components/dashboard/SLATrendChart.tsx
@@ -2,11 +2,12 @@ import { TrendPoint } from "../../types/dashboard";
 
 interface SLATrendChartProps {
   data: TrendPoint[];
+  onPointClick?: (point: TrendPoint) => void;
 }
 
 const clampPercentage = (value: number) => Math.max(0, Math.min(100, value));
 
-const SLATrendChart: React.FC<SLATrendChartProps> = ({ data }) => {
+const SLATrendChart: React.FC<SLATrendChartProps> = ({ data, onPointClick }) => {
   return (
     <div className="rounded-xl bg-white p-5 shadow-sm">
       <h3 className="mb-4 text-sm font-semibold text-gray-600 uppercase tracking-wide">
@@ -17,7 +18,14 @@ const SLATrendChart: React.FC<SLATrendChartProps> = ({ data }) => {
           <p className="text-sm text-gray-500">No trend data available.</p>
         ) : (
           data.map((point) => (
-            <div key={point.period} className="space-y-1">
+            <div
+              key={point.period}
+              className={`space-y-1 ${onPointClick ? "cursor-pointer rounded-lg p-1 hover:bg-gray-50 transition-colors" : ""}`}
+              onClick={() => onPointClick?.(point)}
+              role={onPointClick ? "button" : undefined}
+              tabIndex={onPointClick ? 0 : undefined}
+              onKeyDown={(e) => e.key === "Enter" && onPointClick?.(point)}
+            >
               <div className="flex items-center justify-between text-sm text-gray-600">
                 <span>{point.period}</span>
                 <span>{clampPercentage(point.compliance_percentage).toFixed(1)}%</span>

--- a/src/components/dashboard/sla-dashboard-view.tsx
+++ b/src/components/dashboard/sla-dashboard-view.tsx
@@ -1,14 +1,21 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import KPICard from "@/components/dashboard/KPICard";
 import PenaltiesRewardsChart from "@/components/dashboard/PenaltiesRewardsChart";
 import SLATrendChart from "@/components/dashboard/SLATrendChart";
 import { RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
-import { fetchDashboardMetrics } from "@/services/dashboardService";
-import type { DashboardMetrics } from "@/types/dashboard";
+import { fetchDashboardMetrics, type DashboardFilters } from "@/services/dashboardService";
+import type { DashboardMetrics, TrendPoint } from "@/types/dashboard";
 import { useQuery } from "@tanstack/react-query";
 
+const SEVERITIES = ["", "low", "medium", "high", "critical"];
+
 export default function SLADashboardView() {
+  const router = useRouter();
+  const [filters, setFilters] = useState<DashboardFilters>({});
+
   const {
     data: metrics,
     isLoading,
@@ -16,10 +23,37 @@ export default function SLADashboardView() {
     refetch,
     dataUpdatedAt,
   } = useQuery<DashboardMetrics>({
-    queryKey: ["dashboard-metrics"],
-    queryFn: fetchDashboardMetrics,
+    queryKey: ["dashboard-metrics", filters],
+    queryFn: () => fetchDashboardMetrics(filters),
     staleTime: 30_000,
   });
+
+  function set(key: keyof DashboardFilters, value: string) {
+    setFilters((f) => ({ ...f, [key]: value || undefined }));
+  }
+
+  // FE-076: drilldown — navigate to outages/payments with filter context
+  function onTrendClick(point: TrendPoint) {
+    const params = new URLSearchParams();
+    if (point.period) params.set("date_from", point.period);
+    if (filters.severity) params.set("severity", filters.severity);
+    if (filters.site) params.set("site", filters.site);
+    router.push(`/outages?${params.toString()}`);
+  }
+
+  function onPenaltyClick(point: TrendPoint) {
+    const params = new URLSearchParams();
+    if (point.period) params.set("date_from", point.period);
+    params.set("type", "penalty");
+    router.push(`/payments?${params.toString()}`);
+  }
+
+  function onRewardClick(point: TrendPoint) {
+    const params = new URLSearchParams();
+    if (point.period) params.set("date_from", point.period);
+    params.set("type", "reward");
+    router.push(`/payments?${params.toString()}`);
+  }
 
   if (isLoading) {
     return (
@@ -66,6 +100,50 @@ export default function SLADashboardView() {
         </div>
       </div>
 
+      {/* FE-074 + FE-075: date range + severity/site filters */}
+      <div className="grid grid-cols-2 gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
+        <label className="space-y-1 text-xs">
+          <span className="font-medium text-slate-600">From</span>
+          <input
+            type="date"
+            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
+            value={filters.date_from ?? ""}
+            onChange={(e) => set("date_from", e.target.value)}
+          />
+        </label>
+        <label className="space-y-1 text-xs">
+          <span className="font-medium text-slate-600">To</span>
+          <input
+            type="date"
+            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
+            value={filters.date_to ?? ""}
+            onChange={(e) => set("date_to", e.target.value)}
+          />
+        </label>
+        <label className="space-y-1 text-xs">
+          <span className="font-medium text-slate-600">Severity</span>
+          <select
+            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
+            value={filters.severity ?? ""}
+            onChange={(e) => set("severity", e.target.value)}
+          >
+            {SEVERITIES.map((s) => (
+              <option key={s} value={s}>{s || "All"}</option>
+            ))}
+          </select>
+        </label>
+        <label className="space-y-1 text-xs">
+          <span className="font-medium text-slate-600">Site</span>
+          <input
+            type="text"
+            placeholder="e.g. site-a"
+            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
+            value={filters.site ?? ""}
+            onChange={(e) => set("site", e.target.value)}
+          />
+        </label>
+      </div>
+
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <KPICard
           title="SLA Compliance"
@@ -94,8 +172,13 @@ export default function SLADashboardView() {
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <SLATrendChart data={metrics.trends} />
-        <PenaltiesRewardsChart data={metrics.trends} />
+        {/* FE-076: pass drilldown handlers */}
+        <SLATrendChart data={metrics.trends} onPointClick={onTrendClick} />
+        <PenaltiesRewardsChart
+          data={metrics.trends}
+          onPenaltyClick={onPenaltyClick}
+          onRewardClick={onRewardClick}
+        />
       </div>
     </div>
   );

--- a/src/components/payments/payments-view.tsx
+++ b/src/components/payments/payments-view.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 import { PaymentDetailDrawer } from "@/components/payments/payment-detail-drawer";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
-import { fetchPayments } from "@/services/paymentService";
+import { exportPayments, fetchPayments } from "@/services/paymentService";
 import type { PaginatedPayments, Payment } from "@/types/payment";
 
 type SortKey = "created_at" | "amount" | "status";
@@ -31,6 +31,8 @@ export default function PaymentsView() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedPaymentId, setSelectedPaymentId] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
 
   // FE-069: filter state
   const [statusFilter, setStatusFilter] = useState("");
@@ -98,22 +100,49 @@ export default function PaymentsView() {
   const totalPages = data ? Math.max(1, Math.ceil(data.total / perPage)) : 1;
   const cell = density === "compact" ? "px-3 py-1.5 text-xs" : "px-4 py-3 text-sm";
 
+  async function handleExport() {
+    setExporting(true);
+    setExportError(null);
+    try {
+      await exportPayments({
+        status: statusFilter || undefined,
+        type: typeFilter || undefined,
+        date_from: dateFrom || undefined,
+        date_to: dateTo || undefined,
+      });
+    } catch {
+      setExportError("Export failed. Please try again.");
+    } finally {
+      setExporting(false);
+    }
+  }
+
   return (
     <div className="space-y-4 p-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-800">Payments</h1>
-        {/* FE-072: density toggle */}
-        <div className="flex items-center gap-1 text-xs text-slate-600">
-          <span className="font-medium">Density:</span>
-          {(["default", "compact"] as Density[]).map((d) => (
-            <button
-              key={d}
-              onClick={() => setDensity(d)}
-              className={`rounded px-2 py-0.5 capitalize border ${density === d ? "bg-slate-800 text-white border-slate-800" : "border-slate-200 hover:bg-slate-100"}`}
-            >
-              {d}
-            </button>
-          ))}
+        <div className="flex items-center gap-3">
+          {exportError && <span className="text-xs text-red-600">{exportError}</span>}
+          <button
+            onClick={() => void handleExport()}
+            disabled={exporting}
+            className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50"
+          >
+            {exporting ? "Exporting…" : "Export CSV"}
+          </button>
+          {/* FE-072: density toggle */}
+          <div className="flex items-center gap-1 text-xs text-slate-600">
+            <span className="font-medium">Density:</span>
+            {(["default", "compact"] as Density[]).map((d) => (
+              <button
+                key={d}
+                onClick={() => setDensity(d)}
+                className={`rounded px-2 py-0.5 capitalize border ${density === d ? "bg-slate-800 text-white border-slate-800" : "border-slate-200 hover:bg-slate-100"}`}
+              >
+                {d}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -17,10 +17,18 @@ interface DashboardTrendResponse {
   penalties: number;
 }
 
-export const fetchDashboardMetrics = async (): Promise<DashboardMetrics> => {
+export interface DashboardFilters {
+  date_from?: string;
+  date_to?: string;
+  severity?: string;
+  site?: string;
+}
+
+export const fetchDashboardMetrics = async (filters: DashboardFilters = {}): Promise<DashboardMetrics> => {
+  const params = Object.fromEntries(Object.entries(filters).filter(([, v]) => v));
   const [kpiResponse, trendResponse] = await Promise.all([
-    api.get<DashboardKPIResponse>("/sla/analytics/dashboard"),
-    api.get<DashboardTrendResponse[]>("/sla/analytics/trends"),
+    api.get<DashboardKPIResponse>("/sla/analytics/dashboard", { params }),
+    api.get<DashboardTrendResponse[]>("/sla/analytics/trends", { params }),
   ]);
 
   const kpis = kpiResponse.data;

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -34,3 +34,16 @@ export const reconcilePayment = async (id: string): Promise<Payment> => {
   const response = await api.post<Payment>(`/payments/${id}/reconcile`);
   return response.data;
 };
+
+export const exportPayments = async (filters: Omit<PaymentFilters, "page" | "page_size"> = {}): Promise<void> => {
+  const response = await api.get("/payments/export", {
+    params: filters,
+    responseType: "blob",
+  });
+  const url = URL.createObjectURL(response.data as Blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `payments-${new Date().toISOString().slice(0, 10)}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
Closes #117, closes #118, closes #119, closes #120

- **FE-073**: `exportPayments` in paymentService + Export CSV button in payments view (respects active filters)
- **FE-074**: Date range params (`date_from`/`date_to`) wired through dashboardService and dashboard filter bar
- **FE-075**: Severity and site filter controls on dashboard, passed as query params to both analytics endpoints
- **FE-076**: SLATrendChart rows navigate to `/outages` on click; penalty/reward badges in PenaltiesRewardsChart navigate to `/payments` filtered by type