### PR TITLE
feat: dashboard export, compare mode, bulk import preview + validation

### DIFF
--- a/src/components/bulk-import/bulk-import-view.tsx
+++ b/src/components/bulk-import/bulk-import-view.tsx
@@ -4,15 +4,103 @@ import Link from "next/link";
 import { useRef, useState } from "react";
 
 import { bulkImportOutages } from "@/services/bulkImportService";
-import type { BulkImportResult } from "@/types/bulkImport";
+import type { BulkImportResult, ImportValidationError } from "@/types/bulkImport";
 
 const ACCEPTED_TYPES = ["text/csv", "application/json"];
 const ACCEPTED_EXTENSIONS = [".csv", ".json"];
+const MAX_PREVIEW_ROWS = 5;
+
+interface PreviewState {
+  headers: string[];
+  rows: string[][];
+  warnings: ImportValidationError[];
+  errors: ImportValidationError[];
+}
+
+const REQUIRED_CSV_FIELDS = ["service_id", "start_time", "end_time"];
+
+function parseCSV(text: string): { headers: string[]; rows: string[][] } {
+  const lines = text.trim().split("\n").filter(Boolean);
+  if (lines.length === 0) return { headers: [], rows: [] };
+  const headers = lines[0].split(",").map((h) => h.trim().replace(/^"|"$/g, ""));
+  const rows = lines.slice(1, MAX_PREVIEW_ROWS + 1).map((l) =>
+    l.split(",").map((c) => c.trim().replace(/^"|"$/g, ""))
+  );
+  return { headers, rows };
+}
+
+function validateCSV(headers: string[], rows: string[][]): ImportValidationError[] {
+  const errors: ImportValidationError[] = [];
+  const missing = REQUIRED_CSV_FIELDS.filter((f) => !headers.includes(f));
+  if (missing.length > 0) {
+    errors.push({ message: `Missing required columns: ${missing.join(", ")}` });
+  }
+  rows.forEach((row, i) => {
+    if (row.length !== headers.length) {
+      errors.push({ row: i + 2, message: `Column count mismatch (expected ${headers.length}, got ${row.length})` });
+    }
+  });
+  return errors;
+}
+
+function validateJSON(text: string): ImportValidationError[] {
+  const errors: ImportValidationError[] = [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    errors.push({ message: "Invalid JSON: could not parse file." });
+    return errors;
+  }
+  if (!Array.isArray(parsed)) {
+    errors.push({ message: "JSON must be an array of outage records." });
+    return errors;
+  }
+  (parsed as Record<string, unknown>[]).slice(0, MAX_PREVIEW_ROWS).forEach((item, i) => {
+    REQUIRED_CSV_FIELDS.forEach((field) => {
+      if (item[field] == null) {
+        errors.push({ row: i + 1, field, message: `Missing required field "${field}"` });
+      }
+    });
+  });
+  return errors;
+}
+
+async function buildPreview(file: File): Promise<PreviewState> {
+  const text = await file.text();
+  const ext = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
+
+  if (ext === ".csv") {
+    const { headers, rows } = parseCSV(text);
+    const errors = validateCSV(headers, rows);
+    const warnings: ImportValidationError[] = [];
+    if (rows.length === 0 && errors.length === 0) {
+      warnings.push({ message: "File has a header row but no data rows." });
+    }
+    return { headers, rows, errors, warnings };
+  }
+
+  // JSON
+  const errors = validateJSON(text);
+  let headers: string[] = [];
+  let rows: string[][] = [];
+  if (errors.length === 0) {
+    const parsed = JSON.parse(text) as Record<string, unknown>[];
+    if (parsed.length > 0) {
+      headers = Object.keys(parsed[0]);
+      rows = parsed.slice(0, MAX_PREVIEW_ROWS).map((r) => headers.map((h) => String(r[h] ?? "")));
+    } else {
+      return { headers: [], rows: [], errors: [], warnings: [{ message: "JSON array is empty." }] };
+    }
+  }
+  return { headers, rows, errors, warnings: [] };
+}
 
 export default function BulkImportView() {
   const inputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<BulkImportResult | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -26,40 +114,38 @@ export default function BulkImportView() {
     return null;
   }
 
-  function handleFile(nextFile: File) {
+  async function handleFile(nextFile: File) {
     const validationError = validateFile(nextFile);
     if (validationError) {
       setFileError(validationError);
       setFile(null);
+      setPreview(null);
       return;
     }
-
     setFileError(null);
     setFile(nextFile);
     setResult(null);
     setSubmitError(null);
+    const p = await buildPreview(nextFile);
+    setPreview(p);
   }
 
   function handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
     const nextFile = event.target.files?.[0];
-    if (nextFile) {
-      handleFile(nextFile);
-    }
+    if (nextFile) void handleFile(nextFile);
   }
 
   function handleDrop(event: React.DragEvent<HTMLDivElement>) {
     event.preventDefault();
     setDragging(false);
     const nextFile = event.dataTransfer.files?.[0];
-    if (nextFile) {
-      handleFile(nextFile);
-    }
+    if (nextFile) void handleFile(nextFile);
   }
 
   async function handleSubmit() {
-    if (!file) {
-      return;
-    }
+    if (!file) return;
+    // Block upload if client-side errors found
+    if (preview && preview.errors.length > 0) return;
 
     setLoading(true);
     setSubmitError(null);
@@ -69,9 +155,8 @@ export default function BulkImportView() {
       const response = await bulkImportOutages(file);
       setResult(response);
       setFile(null);
-      if (inputRef.current) {
-        inputRef.current.value = "";
-      }
+      setPreview(null);
+      if (inputRef.current) inputRef.current.value = "";
     } catch {
       setSubmitError("Upload failed. Please try again.");
     } finally {
@@ -82,22 +167,20 @@ export default function BulkImportView() {
   function handleReset() {
     setFile(null);
     setFileError(null);
+    setPreview(null);
     setResult(null);
     setSubmitError(null);
-    if (inputRef.current) {
-      inputRef.current.value = "";
-    }
+    if (inputRef.current) inputRef.current.value = "";
   }
+
+  const hasBlockingErrors = (preview?.errors.length ?? 0) > 0;
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold text-gray-800">Bulk Outage Import</h1>
-          <Link
-            href="/bulk-import/history"
-            className="text-sm text-blue-600 hover:underline"
-          >
+          <Link href="/bulk-import/history" className="text-sm text-blue-600 hover:underline">
             View history →
           </Link>
         </div>
@@ -107,43 +190,22 @@ export default function BulkImportView() {
       </div>
 
       <div
-        onDragOver={(event) => {
-          event.preventDefault();
-          setDragging(true);
-        }}
+        onDragOver={(event) => { event.preventDefault(); setDragging(true); }}
         onDragLeave={() => setDragging(false)}
         onDrop={handleDrop}
         onClick={() => inputRef.current?.click()}
         className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-10 transition-colors ${
-          dragging
-            ? "border-blue-400 bg-blue-50"
-            : "border-gray-300 bg-gray-50 hover:border-blue-300 hover:bg-blue-50"
+          dragging ? "border-blue-400 bg-blue-50" : "border-gray-300 bg-gray-50 hover:border-blue-300 hover:bg-blue-50"
         }`}
       >
-        <svg
-          className="mb-3 h-10 w-10 text-gray-400"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1M12 12V4m0 0L8 8m4-4l4 4"
-          />
+        <svg className="mb-3 h-10 w-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1M12 12V4m0 0L8 8m4-4l4 4" />
         </svg>
         <p className="text-sm font-medium text-gray-600">
           Drag and drop or <span className="text-blue-600 underline">browse</span>
         </p>
         <p className="mt-1 text-xs text-gray-400">Accepted formats: .csv, .json</p>
-        <input
-          ref={inputRef}
-          type="file"
-          accept=".csv,.json"
-          className="hidden"
-          onChange={handleInputChange}
-        />
+        <input ref={inputRef} type="file" accept=".csv,.json" className="hidden" onChange={handleInputChange} />
       </div>
 
       {fileError ? (
@@ -153,15 +215,73 @@ export default function BulkImportView() {
       {file ? (
         <div className="flex items-center justify-between rounded-lg border bg-white px-4 py-3 text-sm text-gray-700 shadow-sm">
           <span className="font-medium">{file.name}</span>
-          <button onClick={handleReset} className="text-gray-400 hover:text-red-500">
-            &#x2715;
-          </button>
+          <button onClick={handleReset} className="text-gray-400 hover:text-red-500">&#x2715;</button>
+        </div>
+      ) : null}
+
+      {/* Client-side validation summary (issues 123 + 124) */}
+      {preview ? (
+        <div className="space-y-3">
+          {preview.errors.length > 0 ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-3">
+              <p className="mb-1 text-sm font-semibold text-red-700">
+                {preview.errors.length} blocking error{preview.errors.length > 1 ? "s" : ""} — fix before uploading
+              </p>
+              <ul className="space-y-0.5">
+                {preview.errors.map((e, i) => (
+                  <li key={i} className="text-xs text-red-600">
+                    {e.row != null ? <span className="font-semibold">Row {e.row}: </span> : null}
+                    {e.field ? <span className="font-semibold">[{e.field}] </span> : null}
+                    {e.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {preview.warnings.length > 0 ? (
+            <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-3">
+              <p className="mb-1 text-sm font-semibold text-yellow-700">Warnings</p>
+              <ul className="space-y-0.5">
+                {preview.warnings.map((w, i) => (
+                  <li key={i} className="text-xs text-yellow-700">{w.message}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {/* File preview table */}
+          {preview.headers.length > 0 && preview.rows.length > 0 ? (
+            <div className="overflow-x-auto rounded-lg border bg-white shadow-sm">
+              <p className="border-b px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Preview (first {preview.rows.length} row{preview.rows.length > 1 ? "s" : ""})
+              </p>
+              <table className="w-full text-xs">
+                <thead className="bg-gray-50">
+                  <tr>
+                    {preview.headers.map((h) => (
+                      <th key={h} className="px-3 py-2 text-left font-semibold text-gray-600">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.rows.map((row, i) => (
+                    <tr key={i} className="border-t">
+                      {row.map((cell, j) => (
+                        <td key={j} className="px-3 py-2 text-gray-700">{cell}</td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
         </div>
       ) : null}
 
       <button
-        onClick={handleSubmit}
-        disabled={!file || loading}
+        onClick={() => void handleSubmit()}
+        disabled={!file || loading || hasBlockingErrors}
         className="w-full rounded-lg bg-blue-600 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40"
       >
         {loading ? "Uploading..." : "Upload File"}

--- a/src/components/dashboard/sla-dashboard-view.tsx
+++ b/src/components/dashboard/sla-dashboard-view.tsx
@@ -7,21 +7,49 @@ import { RouteErrorState, RouteLoadingState } from "@/components/ui/route-state"
 import { fetchDashboardMetrics } from "@/services/dashboardService";
 import type { DashboardMetrics } from "@/types/dashboard";
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+function exportSnapshot(metrics: DashboardMetrics, label = "dashboard") {
+  const snapshot = {
+    exported_at: new Date().toISOString(),
+    label,
+    sla_compliance_percentage: metrics.sla_compliance_percentage,
+    penalties: metrics.penalties,
+    rewards: metrics.rewards,
+    trends: metrics.trends,
+  };
+  const blob = new Blob([JSON.stringify(snapshot, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `sla-snapshot-${label}-${new Date().toISOString().slice(0, 10)}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function delta(a: number, b: number) {
+  const d = a - b;
+  return `${d >= 0 ? "+" : ""}${d.toFixed(1)}`;
+}
 
 export default function SLADashboardView() {
-  const {
-    data: metrics,
-    isLoading,
-    isError,
-    refetch,
-    dataUpdatedAt,
-  } = useQuery<DashboardMetrics>({
+  const [compareMode, setCompareMode] = useState(false);
+
+  const primary = useQuery<DashboardMetrics>({
     queryKey: ["dashboard-metrics"],
     queryFn: fetchDashboardMetrics,
     staleTime: 30_000,
   });
 
-  if (isLoading) {
+  // Second window: same endpoint, separate cache key, only fetched when compare mode is on
+  const secondary = useQuery<DashboardMetrics>({
+    queryKey: ["dashboard-metrics-compare"],
+    queryFn: fetchDashboardMetrics,
+    staleTime: 30_000,
+    enabled: compareMode,
+  });
+
+  if (primary.isLoading) {
     return (
       <RouteLoadingState
         title="Loading dashboard"
@@ -30,19 +58,24 @@ export default function SLADashboardView() {
     );
   }
 
-  if (isError || !metrics) {
+  if (primary.isError || !primary.data) {
     return (
       <RouteErrorState
         title="Dashboard unavailable"
         description="We could not load the latest analytics right now."
         actionLabel="Retry"
-        onAction={() => void refetch()}
+        onAction={() => void primary.refetch()}
       />
     );
   }
 
+  const metrics = primary.data;
   const netBalance = metrics.rewards.total - metrics.penalties.total;
-  const lastUpdated = dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleString() : "Not synced yet";
+  const lastUpdated = primary.dataUpdatedAt
+    ? new Date(primary.dataUpdatedAt).toLocaleString()
+    : "Not synced yet";
+
+  const cmp = compareMode && secondary.data ? secondary.data : null;
 
   return (
     <div className="space-y-6 p-6">
@@ -53,12 +86,28 @@ export default function SLADashboardView() {
             Live backend analytics for compliance, payouts, and trend movement.
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="text-xs uppercase tracking-wide text-gray-400">
             Updated {lastUpdated}
           </span>
           <button
-            onClick={() => void refetch()}
+            onClick={() => setCompareMode((v) => !v)}
+            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+              compareMode
+                ? "border-blue-400 bg-blue-50 text-blue-700"
+                : "border-gray-200 text-gray-600 hover:bg-gray-50"
+            }`}
+          >
+            {compareMode ? "Exit Compare" : "Compare"}
+          </button>
+          <button
+            onClick={() => exportSnapshot(metrics)}
+            className="rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
+          >
+            Export
+          </button>
+          <button
+            onClick={() => void primary.refetch()}
             className="rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
           >
             Refresh
@@ -66,29 +115,37 @@ export default function SLADashboardView() {
         </div>
       </div>
 
+      {compareMode && secondary.isLoading ? (
+        <p className="text-sm text-gray-400">Loading comparison window…</p>
+      ) : null}
+
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <KPICard
           title="SLA Compliance"
           value={`${metrics.sla_compliance_percentage.toFixed(1)}%`}
-          subtitle="Overall compliance rate"
+          subtitle={cmp ? `vs ${cmp.sla_compliance_percentage.toFixed(1)}% (${delta(metrics.sla_compliance_percentage, cmp.sla_compliance_percentage)}pp)` : "Overall compliance rate"}
           highlight={metrics.sla_compliance_percentage >= 90 ? "green" : "red"}
         />
         <KPICard
           title="Total Penalties"
           value={`$${metrics.penalties.total.toLocaleString()}`}
-          subtitle={`${metrics.penalties.count} incidents`}
+          subtitle={cmp ? `vs $${cmp.penalties.total.toLocaleString()} (${delta(metrics.penalties.total, cmp.penalties.total)})` : `${metrics.penalties.count} incidents`}
           highlight="red"
         />
         <KPICard
           title="Total Rewards"
           value={`$${metrics.rewards.total.toLocaleString()}`}
-          subtitle={`${metrics.rewards.count} achievements`}
+          subtitle={cmp ? `vs $${cmp.rewards.total.toLocaleString()} (${delta(metrics.rewards.total, cmp.rewards.total)})` : `${metrics.rewards.count} achievements`}
           highlight="green"
         />
         <KPICard
           title="Net Balance"
           value={`${netBalance >= 0 ? "+" : ""}$${netBalance.toLocaleString()}`}
-          subtitle="Rewards minus penalties"
+          subtitle={(() => {
+            if (!cmp) return "Rewards minus penalties";
+            const cmpNet = cmp.rewards.total - cmp.penalties.total;
+            return `vs ${cmpNet >= 0 ? "+" : ""}$${cmpNet.toLocaleString()} (${delta(netBalance, cmpNet)})`;
+          })()}
           highlight={netBalance >= 0 ? "green" : "red"}
         />
       </div>
@@ -97,6 +154,24 @@ export default function SLADashboardView() {
         <SLATrendChart data={metrics.trends} />
         <PenaltiesRewardsChart data={metrics.trends} />
       </div>
+
+      {cmp && cmp.trends.length > 0 ? (
+        <div>
+          <p className="mb-3 text-sm font-semibold text-gray-500 uppercase tracking-wide">
+            Comparison Window
+          </p>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <SLATrendChart data={cmp.trends} />
+            <PenaltiesRewardsChart data={cmp.trends} />
+          </div>
+        </div>
+      ) : null}
+
+      {compareMode && cmp && cmp.trends.length === 0 ? (
+        <p className="rounded-lg bg-yellow-50 px-4 py-2 text-sm text-yellow-700">
+          No data available for the comparison window.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -17,3 +17,14 @@ export interface DashboardMetrics {
   };
   trends: TrendPoint[];
 }
+
+export interface CompareWindow {
+  label: string;
+  from: string;
+  to: string;
+}
+
+export interface CompareMetrics {
+  a: DashboardMetrics;
+  b: DashboardMetrics;
+}


### PR DESCRIPTION
Closes #121, closes #122, closes #123, closes #124

- **#121** Export snapshot button downloads current dashboard state as JSON
- **#122** Compare mode toggle fetches a second metrics window; KPI subtitles show deltas; empty window degrades gracefully
- **#123** File preview table renders first 5 rows of CSV/JSON before upload
- **#124** Client-side validation surfaces blocking errors (missing columns/fields, malformed JSON) and warnings; blocking errors disable the upload button