### PR TITLE
feat: toast, explorer links, payment deep links, api-types doc

### DIFF
--- a/docs/api-types.md
+++ b/docs/api-types.md
@@ -1,0 +1,45 @@
+# API Type Synchronization Strategy
+
+## Problem
+
+Frontend types in `src/types/` and backend response shapes in `noc-iq-be` evolve independently. Without a sync strategy, type drift causes silent runtime failures in service modules and view components.
+
+## Strategy
+
+### Source of truth
+
+The backend (`noc-iq-be`) owns the canonical API contract. The frontend mirrors it in `src/types/`.
+
+### Sync approach (manual + review-gated)
+
+Until the backend exposes an OpenAPI spec, the process is:
+
+1. **On every backend change** that touches a response shape, the backend PR must update `src/types/` in this repo (or open a linked FE issue).
+2. **High-risk models** (listed below) are reviewed on every PR that touches `src/services/` or `src/types/`.
+3. **Type assertions are banned** — no `as SomeType` casts on raw API responses. Use typed generics (`api.get<T>`) so TypeScript catches shape mismatches at compile time.
+
+### High-risk shared models
+
+| Type | File | Backend endpoint |
+|------|------|-----------------|
+| `Payment` | `src/types/payment.ts` | `GET /payments/:id` |
+| `Outage` | `src/types/outages.ts` | `GET /outages/:id` |
+| `SLAResult` | `src/types/outages.ts` | embedded in outage resolve response |
+| `OutageResolutionPayment` | `src/types/outages.ts` | `POST /outages/:id/resolve` |
+
+### Future: OpenAPI codegen
+
+When `noc-iq-be` publishes an OpenAPI spec (`/openapi.json`), replace manual types with generated ones:
+
+```bash
+npx openapi-typescript http://localhost:8000/openapi.json -o src/types/api.generated.ts
+```
+
+Then re-export the relevant types from `src/types/` wrappers so call sites don't change.
+
+### Checklist for service changes
+
+- [ ] Does the response shape match the current backend?
+- [ ] Are optional fields (`?`) correctly marked?
+- [ ] Are new fields added to the type before using them in components?
+- [ ] Does `npm run build` pass with no type errors?

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import Navigation from "@/components/Navigation";
 import RouteGuard from "@/components/RouteGuard";
 import { ReactQueryProvider } from "@/providers/react-query";
+import { ToastProvider } from "@/components/ui/toast";
 
 export const metadata = {
   title: "NOCIQ",
@@ -18,10 +19,12 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html lang="en">
       <body>
         <ReactQueryProvider>
-          <RouteGuard>
-            <Navigation />
-            {children}
-          </RouteGuard>
+          <ToastProvider>
+            <RouteGuard>
+              <Navigation />
+              {children}
+            </RouteGuard>
+          </ToastProvider>
         </ReactQueryProvider>
       </body>
     </html>

--- a/src/app/outages/[id]/page.tsx
+++ b/src/app/outages/[id]/page.tsx
@@ -1,32 +1,22 @@
 "use client";
 
-import { useState } from "react";
-import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 
-import { ResolveOutageModal } from "@/features/outages/components/ResolveOutageModal";
-import { useOutage, useResolveOutage } from "@/features/outages/hooks/useOutageMutations";
 import { SLADisputesPanel } from "@/components/outages/SLADisputesPanel";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { Separator } from "@/components/ui/separator";
-import type { OutageResolutionPayment } from "@/types/outages";
-
-export default function OutageDetailsPage() {
-  const params = useParams<{ id: string }>();
-  const id = params?.id ?? "";
-import { getOutage, resolveOutage, updateOutage } from "@/services/outages";
+import { useToast } from "@/components/ui/toast";
+import { ResolveOutageModal } from "@/features/outages/components/ResolveOutageModal";
+import { getOutage, resolveOutage, updateOutage, deleteOutage } from "@/services/outages";
 import type { Outage, OutageResolutionPayment, OutageUpdate, Severity, OutageStatus } from "@/types/outages";
-import { getOutage, resolveOutage, deleteOutage } from "@/services/outages";
-import type { Outage, OutageResolutionPayment } from "@/types/outages";
 
 function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Failed to load outage";
 }
 
-// FE-020: derive timeline events from outage data
 function buildTimeline(outage: Outage) {
   const events: { label: string; time: string; note?: string }[] = [];
   events.push({ label: "Outage detected", time: outage.detected_at });
@@ -46,6 +36,7 @@ function buildTimeline(outage: Outage) {
 export default function OutageDetailsPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
+  const toast = useToast();
   const id = params?.id;
   const [outage, setOutage] = useState<Outage | null>(null);
   const [loading, setLoading] = useState(true);
@@ -54,11 +45,9 @@ export default function OutageDetailsPage() {
   const [isResolveModalOpen, setIsResolveModalOpen] = useState(false);
   const [resolutionPayment, setResolutionPayment] = useState<OutageResolutionPayment | null>(null);
 
-  // FE-018: edit state
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [editForm, setEditForm] = useState<OutageUpdate>({});
-  // Delete state
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -66,16 +55,6 @@ export default function OutageDetailsPage() {
   const isFetching = useRef(false);
   const hasOutageRef = useRef(false);
 
-  const { data: outage, isLoading, isError } = useOutage(id);
-  const resolveMutation = useResolveOutage(id);
-
-  const [isResolveModalOpen, setIsResolveModalOpen] = useState(false);
-  const [resolutionPayment, setResolutionPayment] = useState<OutageResolutionPayment | null>(null);
-
-  async function handleResolve(mttrMinutes: number) {
-    const result = await resolveMutation.mutateAsync(mttrMinutes);
-    setResolutionPayment(result.payment);
-    setIsResolveModalOpen(false);
   useEffect(() => {
     hasOutageRef.current = outage !== null;
   }, [outage]);
@@ -89,14 +68,9 @@ export default function OutageDetailsPage() {
       isFetching.current = true;
       try {
         const data = await getOutage(id);
-        if (isMounted) {
-          setOutage(data);
-          setError(null);
-        }
+        if (isMounted) { setOutage(data); setError(null); }
       } catch (issue) {
-        if (isMounted && !hasOutageRef.current) {
-          setError(getErrorMessage(issue));
-        }
+        if (isMounted && !hasOutageRef.current) setError(getErrorMessage(issue));
       } finally {
         isFetching.current = false;
         if (isMounted) setLoading(false);
@@ -104,13 +78,8 @@ export default function OutageDetailsPage() {
     };
 
     void fetchOutage();
-    const intervalId =
-      outage?.status === "resolved" ? null : setInterval(() => void fetchOutage(), 15000);
-
-    return () => {
-      isMounted = false;
-      if (intervalId) clearInterval(intervalId);
-    };
+    const intervalId = outage?.status === "resolved" ? null : setInterval(() => void fetchOutage(), 15000);
+    return () => { isMounted = false; if (intervalId) clearInterval(intervalId); };
   }, [id, outage?.status]);
 
   function startEdit() {
@@ -135,6 +104,7 @@ export default function OutageDetailsPage() {
       const updated = await updateOutage(id, editForm);
       setOutage({ ...outage, ...updated });
       setEditing(false);
+      toast("Outage updated.", "success");
     } catch (issue) {
       setError(getErrorMessage(issue));
     } finally {
@@ -151,14 +121,16 @@ export default function OutageDetailsPage() {
       setOutage({ ...updated.outage, sla_status: updated.sla });
       setResolutionPayment(updated.payment);
       setIsResolveModalOpen(false);
+      toast("Outage resolved successfully.", "success");
     } catch (issue) {
-      setError(getErrorMessage(issue));
+      const msg = getErrorMessage(issue);
+      setError(msg);
+      toast(msg, "error");
     } finally {
       setResolving(false);
     }
   }
 
-  if (isLoading) {
   async function handleDelete() {
     if (!id) return;
     setDeleting(true);
@@ -181,11 +153,11 @@ export default function OutageDetailsPage() {
     );
   }
 
-  if (isError) {
+  if (error && !outage) {
     return (
       <RouteErrorState
         title="Error loading outage"
-        description="Failed to load outage"
+        description={error}
         actionLabel="Reload page"
         onAction={() => window.location.reload()}
       />
@@ -209,26 +181,11 @@ export default function OutageDetailsPage() {
       <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <div className="flex items-center gap-3">
           <h1 className="text-3xl font-bold tracking-tight">Outage {outage.id}</h1>
-          <Badge
-            variant={outage.status === "open" ? "destructive" : "default"}
-            className="uppercase"
-          >
+          <Badge variant={outage.status === "open" ? "destructive" : "default"} className="uppercase">
             {outage.status}
           </Badge>
         </div>
-
-        <button
-          onClick={() => setIsResolveModalOpen(true)}
-          disabled={isResolved || resolveMutation.isPending}
-          className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-            isResolved
-              ? "cursor-not-allowed bg-gray-100 text-gray-500"
-              : "bg-blue-600 text-white hover:bg-blue-700"
-          }`}
-        >
-          {isResolved ? "Outage Resolved" : resolveMutation.isPending ? "Resolving…" : "Resolve Outage"}
-        </button>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
           {!editing && (
             <button
               onClick={startEdit}
@@ -237,7 +194,6 @@ export default function OutageDetailsPage() {
               Edit
             </button>
           )}
-        <div className="flex items-center gap-2">
           <button
             onClick={() => setIsResolveModalOpen(true)}
             disabled={isResolved || resolving}
@@ -258,20 +214,15 @@ export default function OutageDetailsPage() {
         </div>
       </div>
 
-      {resolveMutation.isError && (
+      {error && (
         <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
-          {resolveMutation.error instanceof Error
-            ? resolveMutation.error.message
-            : "Failed to resolve outage"}
+          {error}
         </div>
       )}
 
-      {/* FE-018: Inline edit panel */}
       {editing && (
         <Card>
-          <CardHeader className="pb-3">
-            <CardTitle>Edit Outage</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>Edit Outage</CardTitle></CardHeader>
           <CardContent className="space-y-4 text-sm">
             <div className="grid gap-4 sm:grid-cols-2">
               <div>
@@ -324,9 +275,7 @@ export default function OutageDetailsPage() {
               />
             </div>
             <div>
-              <label className="mb-1 block font-medium text-slate-700">
-                Affected Services (comma-separated)
-              </label>
+              <label className="mb-1 block font-medium text-slate-700">Affected Services (comma-separated)</label>
               <input
                 className="w-full rounded-md border border-slate-200 px-3 py-2"
                 value={(editForm.affected_services ?? []).join(", ")}
@@ -339,17 +288,8 @@ export default function OutageDetailsPage() {
               />
             </div>
             <div className="flex justify-end gap-2 pt-1">
-              <button
-                onClick={() => setEditing(false)}
-                className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSaveEdit}
-                disabled={saving}
-                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
-              >
+              <button onClick={() => setEditing(false)} className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Cancel</button>
+              <button onClick={handleSaveEdit} disabled={saving} className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60">
                 {saving ? "Saving…" : "Save Changes"}
               </button>
             </div>
@@ -359,9 +299,7 @@ export default function OutageDetailsPage() {
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         <Card>
-          <CardHeader className="pb-3">
-            <CardTitle>Metadata</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>Metadata</CardTitle></CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div className="flex items-center justify-between">
               <span className="text-muted-foreground">Site Name</span>
@@ -370,17 +308,13 @@ export default function OutageDetailsPage() {
             <Separator />
             <div className="flex items-center justify-between">
               <span className="text-muted-foreground">Severity</span>
-              <Badge variant={outage.severity === "high" ? "destructive" : "secondary"}>
-                {outage.severity}
-              </Badge>
+              <Badge variant={outage.severity === "high" ? "destructive" : "secondary"}>{outage.severity}</Badge>
             </div>
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader className="pb-3">
-            <CardTitle>Timeline</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>Timeline</CardTitle></CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div className="flex items-center justify-between">
               <span className="text-muted-foreground">Started At</span>
@@ -389,17 +323,13 @@ export default function OutageDetailsPage() {
             <Separator />
             <div className="flex items-center justify-between">
               <span className="text-muted-foreground">Resolved At</span>
-              <span className="font-medium">
-                {outage.resolved_at ? new Date(outage.resolved_at).toLocaleString() : "Ongoing"}
-              </span>
+              <span className="font-medium">{outage.resolved_at ? new Date(outage.resolved_at).toLocaleString() : "Ongoing"}</span>
             </div>
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader className="pb-3">
-            <CardTitle>SLA Result</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>SLA Result</CardTitle></CardHeader>
           <CardContent className="space-y-3 text-sm">
             {outage.sla_status ? (
               <>
@@ -415,13 +345,8 @@ export default function OutageDetailsPage() {
                 <Separator />
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">Amount</span>
-                  <span
-                    className={`font-semibold ${
-                      outage.sla_status.amount > 0 ? "text-green-600" : "text-red-600"
-                    }`}
-                  >
-                    {outage.sla_status.amount > 0 ? "+" : ""}
-                    {outage.sla_status.amount}
+                  <span className={`font-semibold ${outage.sla_status.amount > 0 ? "text-green-600" : "text-red-600"}`}>
+                    {outage.sla_status.amount > 0 ? "+" : ""}{outage.sla_status.amount}
                   </span>
                 </div>
               </>
@@ -432,9 +357,7 @@ export default function OutageDetailsPage() {
         </Card>
 
         <Card>
-          <CardHeader className="pb-3">
-            <CardTitle>Resolution Payment</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>Resolution Payment</CardTitle></CardHeader>
           <CardContent className="space-y-3 text-sm">
             {resolutionPayment ? (
               <>
@@ -445,38 +368,26 @@ export default function OutageDetailsPage() {
                 <Separator />
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">Amount</span>
-                  <span className="font-medium text-slate-900">
-                    {resolutionPayment.amount} {resolutionPayment.asset_code}
-                  </span>
+                  <span className="font-medium text-slate-900">{resolutionPayment.amount} {resolutionPayment.asset_code}</span>
                 </div>
                 <Separator />
                 <div className="flex items-center justify-between gap-4">
                   <span className="text-muted-foreground">Transaction</span>
-                  <span className="break-all text-right font-medium text-slate-900">
-                    {resolutionPayment.transaction_hash}
-                  </span>
+                  <span className="break-all text-right font-medium text-slate-900">{resolutionPayment.transaction_hash}</span>
                 </div>
               </>
             ) : (
-              <span className="italic text-muted-foreground">
-                Resolve the outage to view the generated payment record.
-              </span>
+              <span className="italic text-muted-foreground">Resolve the outage to view the generated payment record.</span>
             )}
           </CardContent>
         </Card>
 
         <Card className="md:col-span-2">
-          <CardHeader className="pb-3">
-            <CardTitle>Impact</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>Impact</CardTitle></CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div className="flex items-center justify-between">
               <span className="text-muted-foreground">Affected Services</span>
-              <span className="font-medium">
-                {outage.affected_services.length > 0
-                  ? outage.affected_services.join(", ")
-                  : "Not provided"}
-              </span>
+              <span className="font-medium">{outage.affected_services.length > 0 ? outage.affected_services.join(", ") : "Not provided"}</span>
             </div>
             <Separator />
             <div className="flex items-center justify-between">
@@ -486,11 +397,8 @@ export default function OutageDetailsPage() {
           </CardContent>
         </Card>
 
-        {/* FE-020: Outage history / timeline panel */}
         <Card className="md:col-span-2">
-          <CardHeader className="pb-3">
-            <CardTitle>Outage History</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>Outage History</CardTitle></CardHeader>
           <CardContent>
             {timeline.length === 0 ? (
               <p className="text-sm italic text-muted-foreground">No history events available yet.</p>
@@ -501,17 +409,16 @@ export default function OutageDetailsPage() {
                     <span className="absolute -left-[1.35rem] top-1 h-3 w-3 rounded-full border-2 border-blue-500 bg-white" />
                     <p className="text-sm font-medium text-slate-900">{event.label}</p>
                     <p className="text-xs text-slate-500">{new Date(event.time).toLocaleString()}</p>
-                    {event.note && (
-                      <p className="mt-0.5 text-xs text-slate-400">{event.note}</p>
-                    )}
+                    {event.note && <p className="mt-0.5 text-xs text-slate-400">{event.note}</p>}
                   </li>
                 ))}
               </ol>
-        {/* FE-063: Location visualization */}
+            )}
+          </CardContent>
+        </Card>
+
         <Card className="md:col-span-2">
-          <CardHeader className="pb-3">
-            <CardTitle>Location</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>Location</CardTitle></CardHeader>
           <CardContent className="text-sm">
             {outage.location ? (
               <div className="space-y-3">
@@ -526,7 +433,6 @@ export default function OutageDetailsPage() {
                   </div>
                 </div>
                 <div className="relative w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-50" style={{ paddingBottom: "40%" }}>
-                  {/* Static map via OpenStreetMap tile — no API key required */}
                   <iframe
                     title="Outage location map"
                     className="absolute inset-0 h-full w-full"
@@ -545,11 +451,8 @@ export default function OutageDetailsPage() {
           </CardContent>
         </Card>
 
-        {/* FE-064: Root cause and resolution notes */}
         <Card className="md:col-span-2">
-          <CardHeader className="pb-3">
-            <CardTitle>Post-Incident Analysis</CardTitle>
-          </CardHeader>
+          <CardHeader className="pb-3"><CardTitle>Post-Incident Analysis</CardTitle></CardHeader>
           <CardContent className="space-y-4 text-sm">
             <div>
               <p className="font-medium text-slate-700 mb-1">Root Cause</p>
@@ -575,70 +478,33 @@ export default function OutageDetailsPage() {
       </div>
 
       <ResolveOutageModal
-        key={`${outage.id}-${outage.sla_status?.mttr_minutes ?? "empty"}-${isResolveModalOpen ? "open" : "closed"}`}
         outageId={outage.id}
         siteName={outage.site_name}
         severity={outage.severity}
         initialMttrMinutes={outage.sla_status?.mttr_minutes}
         isOpen={isResolveModalOpen}
-        isResolving={resolveMutation.isPending}
-        error={
-          resolveMutation.isError
-            ? resolveMutation.error instanceof Error
-              ? resolveMutation.error.message
-              : "Failed to resolve outage"
-            : null
-        }
-        onClose={() => {
-          if (!resolveMutation.isPending) {
-            setIsResolveModalOpen(false);
-          }
-        }}
+        isResolving={resolving}
+        error={error}
+        onClose={() => { if (!resolving) setIsResolveModalOpen(false); }}
         onConfirmResolve={(mttr) => handleResolve(mttr)}
       />
 
-      {/* FE-062: Delete confirmation dialog */}
       {showDeleteConfirm && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="delete-dialog-title"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-        >
+        <div role="dialog" aria-modal="true" aria-labelledby="delete-dialog-title" className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
           <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl space-y-4">
-            <h2 id="delete-dialog-title" className="text-lg font-semibold text-slate-900">
-              Delete outage?
-            </h2>
+            <h2 id="delete-dialog-title" className="text-lg font-semibold text-slate-900">Delete outage?</h2>
             <p className="text-sm text-slate-600">
-              This will permanently delete outage{" "}
-              <span className="font-medium">{outage.id}</span> ({outage.site_name}). This action
-              cannot be undone.
+              This will permanently delete outage <span className="font-medium">{outage.id}</span> ({outage.site_name}). This action cannot be undone.
             </p>
             {deleteError && (
               <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
                 {deleteError}{" "}
-                <button
-                  className="underline font-medium"
-                  onClick={handleDelete}
-                  disabled={deleting}
-                >
-                  Retry
-                </button>
+                <button className="underline font-medium" onClick={handleDelete} disabled={deleting}>Retry</button>
               </div>
             )}
             <div className="flex justify-end gap-2">
-              <button
-                onClick={() => { setShowDeleteConfirm(false); setDeleteError(null); }}
-                disabled={deleting}
-                className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium hover:bg-slate-50 disabled:opacity-50"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleDelete}
-                disabled={deleting}
-                className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
-              >
+              <button onClick={() => { setShowDeleteConfirm(false); setDeleteError(null); }} disabled={deleting} className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium hover:bg-slate-50 disabled:opacity-50">Cancel</button>
+              <button onClick={handleDelete} disabled={deleting} className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50">
                 {deleting ? "Deleting…" : "Delete"}
               </button>
             </div>

--- a/src/app/outages/components/outages-page-client.tsx
+++ b/src/app/outages/components/outages-page-client.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import type { VisibilityState } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
 
 import { DataTable, type TableDensity } from "@/components/data-table";
 import ExportDropdown from "@/components/outages/ExportDropdown";
@@ -10,10 +11,9 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { useOutages } from "@/features/outages/hooks/useOutages";
-import { useFilterPresets, useOutagesTableState } from "@/hooks/useOutagesTableState";
+import { useFilterPresets, useOutagesTableState, type SortField, type SortOrder } from "@/hooks/useOutagesTableState";
 import { deleteOutage } from "@/services/outages";
 import type { Outage } from "@/types/outages";
-import type { ColumnDef } from "@tanstack/react-table";
 
 const VISIBILITY_KEY = "outages-table-visibility";
 const DENSITY_KEY = "outages-table-density";
@@ -37,186 +37,43 @@ const DEFAULT_VISIBILITY: VisibilityState = {
   affected_services: true,
 };
 
-// Non-critical columns that can be toggled off
-const OPTIONAL_COLUMNS = new Set(["detected_at", "affected_services"]);
-import { useFilterPresets, useOutagesTableState, type SortField, type SortOrder } from "@/hooks/useOutagesTableState";
-import type { Outage } from "@/types/outages";
-import type { ColumnDef } from "@tanstack/react-table";
-
 const SORT_FIELDS: { value: SortField; label: string }[] = [
   { value: "detected_at", label: "Detected" },
   { value: "severity", label: "Severity" },
   { value: "status", label: "Status" },
 ];
 
-function SortHeader({
-  label,
-  field,
-  currentField,
-  currentOrder,
-  onSort,
-}: {
-  label: string;
-  field: SortField;
-  currentField?: SortField;
-  currentOrder: SortOrder;
-  onSort: (field: SortField, order: SortOrder) => void;
-}) {
-  const isActive = currentField === field;
-  const nextOrder: SortOrder = isActive && currentOrder === "asc" ? "desc" : "asc";
-  return (
-    <button
-      className="flex items-center gap-1 font-medium hover:text-slate-900"
-      onClick={() => onSort(field, nextOrder)}
-      aria-label={`Sort by ${label}`}
-    >
-      {label}
-      <span className="text-slate-400">
-        {isActive ? (currentOrder === "asc" ? "↑" : "↓") : "↕"}
-      </span>
-    </button>
-  );
-}
-
 export function OutagesPageClient() {
   const { state, actions } = useOutagesTableState();
   const { presets, savePreset, deletePreset } = useFilterPresets();
-  const { data, isLoading, isError, refetch } = useOutages(state);
+
+  const sortParam = state.sort_field ? `${state.sort_field}:${state.sort_order}` : undefined;
+  const { data, isLoading, isError, refetch } = useOutages({
+    page: state.page,
+    page_size: state.page_size,
+    severity: state.severity,
+    status: state.status,
+    search: state.search,
+    sort: sortParam,
+  });
+
   const totalItems = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(totalItems / state.page_size));
   const [presetName, setPresetName] = useState("");
+  const [searchInput, setSearchInput] = useState(state.search ?? "");
 
-  // Column visibility (persisted)
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() =>
     loadFromStorage(VISIBILITY_KEY, DEFAULT_VISIBILITY)
   );
-
-  // Density (persisted)
   const [density, setDensity] = useState<TableDensity>(() =>
     loadFromStorage<TableDensity>(DENSITY_KEY, "default")
   );
-
-  // Delete confirmation state
   const [pendingDelete, setPendingDelete] = useState<Outage | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
-    const { state, actions } = useOutagesTableState();
-    const { presets, savePreset, deletePreset } = useFilterPresets();
 
-    // Build sort param for API: "field:order"
-    const sortParam = state.sort_field
-      ? `${state.sort_field}:${state.sort_order}`
-      : undefined;
-
-    const { data, isLoading, isError } = useOutages({
-      page: state.page,
-      page_size: state.page_size,
-      severity: state.severity,
-      status: state.status,
-      search: state.search,
-      sort: sortParam,
-    });
-
-    const totalItems = data?.total ?? 0;
-    const totalPages = Math.max(1, Math.ceil(totalItems / state.page_size));
-    const [presetName, setPresetName] = useState("");
-    const [searchInput, setSearchInput] = useState(state.search ?? "");
-
-    const columns: ColumnDef<Outage>[] = [
-      {
-        accessorKey: "id",
-        header: () => (
-          <SortHeader
-            label="Outage"
-            field="detected_at"
-            currentField={state.sort_field}
-            currentOrder={state.sort_order}
-            onSort={actions.setSort}
-          />
-        ),
-        cell: ({ row }) => (
-          <Link
-            href={`/outages/${row.original.id}`}
-            className="font-medium text-blue-600 underline-offset-4 hover:underline"
-          >
-            {row.original.id}
-          </Link>
-        ),
-      },
-      {
-        accessorKey: "site_name",
-        header: "Site",
-      },
-      {
-        accessorKey: "severity",
-        header: () => (
-          <SortHeader
-            label="Severity"
-            field="severity"
-            currentField={state.sort_field}
-            currentOrder={state.sort_order}
-            onSort={actions.setSort}
-          />
-        ),
-        cell: ({ row }) => (
-          <Badge variant={row.original.severity === "critical" ? "destructive" : "secondary"}>
-            {row.original.severity}
-          </Badge>
-        ),
-      },
-      {
-        accessorKey: "status",
-        header: () => (
-          <SortHeader
-            label="Status"
-            field="status"
-            currentField={state.sort_field}
-            currentOrder={state.sort_order}
-            onSort={actions.setSort}
-          />
-        ),
-        cell: ({ row }) => (
-          <Badge variant={row.original.status === "resolved" ? "secondary" : "outline"}>
-            {row.original.status}
-          </Badge>
-        ),
-      },
-      {
-        accessorKey: "detected_at",
-        header: () => (
-          <SortHeader
-            label="Detected"
-            field="detected_at"
-            currentField={state.sort_field}
-            currentOrder={state.sort_order}
-            onSort={actions.setSort}
-          />
-        ),
-        cell: ({ row }) => new Date(row.original.detected_at).toLocaleString(),
-      },
-      {
-        accessorKey: "affected_services",
-        header: "Services",
-        cell: ({ row }) => row.original.affected_services.join(", "),
-      },
-    ];
-
-    if (isLoading) {
-        return (
-            <RouteLoadingState
-                title="Loading outages"
-                description="Gathering the latest incidents and applying your saved filters."
-            />
-        );
-    }
-
-  useEffect(() => {
-    localStorage.setItem(VISIBILITY_KEY, JSON.stringify(columnVisibility));
-  }, [columnVisibility]);
-
-  useEffect(() => {
-    localStorage.setItem(DENSITY_KEY, JSON.stringify(density));
-  }, [density]);
+  useEffect(() => { localStorage.setItem(VISIBILITY_KEY, JSON.stringify(columnVisibility)); }, [columnVisibility]);
+  useEffect(() => { localStorage.setItem(DENSITY_KEY, JSON.stringify(density)); }, [density]);
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!pendingDelete) return;
@@ -238,18 +95,12 @@ export function OutagesPageClient() {
       accessorKey: "id",
       header: "Outage",
       cell: ({ row }) => (
-        <Link
-          href={`/outages/${row.original.id}`}
-          className="font-medium text-blue-600 underline-offset-4 hover:underline"
-        >
+        <Link href={`/outages/${row.original.id}`} className="font-medium text-blue-600 underline-offset-4 hover:underline">
           {row.original.id}
         </Link>
       ),
     },
-    {
-      accessorKey: "site_name",
-      header: "Site",
-    },
+    { accessorKey: "site_name", header: "Site" },
     {
       accessorKey: "severity",
       header: "Severity",
@@ -295,21 +146,6 @@ export function OutagesPageClient() {
 
   if (isLoading) {
     return (
-        <div className="space-y-6 p-6">
-            <div className="flex items-start justify-between gap-4">
-                <div className="space-y-1">
-                    <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Outages</h1>
-                    <p className="text-sm text-slate-500">
-                        Review live incidents, filter by severity and status, and page through the active outage feed.
-                    </p>
-                </div>
-                <Link
-                    href="/outages/new"
-                    className="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-                >
-                    + New Outage
-                </Link>
-            </div>
       <RouteLoadingState
         title="Loading outages"
         description="Gathering the latest incidents and applying your saved filters."
@@ -332,21 +168,41 @@ export function OutagesPageClient() {
 
   return (
     <div className="space-y-6 p-6">
-      <div className="space-y-1">
-        <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Outages</h1>
-        <p className="text-sm text-slate-500">
-          Review live incidents, filter by severity and status, and page through the active outage feed.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Outages</h1>
+          <p className="text-sm text-slate-500">
+            Review live incidents, filter by severity and status, and page through the active outage feed.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <ExportDropdown filters={{ severity: state.severity, status: state.status }} />
+          <Link href="/outages/new" className="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">
+            + New Outage
+          </Link>
+        </div>
       </div>
 
-      <div className="flex justify-end">
-        <ExportDropdown
-          filters={{
-            severity: state.severity,
-            status: state.status,
-          }}
+      {/* Search */}
+      <form
+        className="flex items-center gap-2"
+        onSubmit={(e) => { e.preventDefault(); actions.setSearch(searchInput.trim() || undefined); }}
+      >
+        <input
+          type="search"
+          className="flex-1 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
+          placeholder="Search by site ID, site name, or outage ID…"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          aria-label="Search outages"
         />
-      </div>
+        <Button type="submit" variant="outline" className="text-sm">Search</Button>
+        {state.search && (
+          <Button type="button" variant="ghost" className="text-sm text-slate-500" onClick={() => { setSearchInput(""); actions.setSearch(undefined); }}>
+            Clear
+          </Button>
+        )}
+      </form>
 
       {/* Filter presets */}
       <div className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
@@ -355,20 +211,11 @@ export function OutagesPageClient() {
           <div key={preset.name} className="flex items-center gap-1">
             <button
               className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100"
-              onClick={() => {
-                actions.setSeverity(preset.severity);
-                actions.setStatus(preset.status);
-              }}
+              onClick={() => { actions.setSeverity(preset.severity); actions.setStatus(preset.status); }}
             >
               {preset.name}
             </button>
-            <button
-              className="text-slate-400 hover:text-red-500 text-xs"
-              onClick={() => deletePreset(preset.name)}
-              aria-label={`Delete preset ${preset.name}`}
-            >
-              ×
-            </button>
+            <button className="text-slate-400 hover:text-red-500 text-xs" onClick={() => deletePreset(preset.name)} aria-label={`Delete preset ${preset.name}`}>×</button>
           </div>
         ))}
         <div className="ml-auto flex items-center gap-2">
@@ -378,28 +225,17 @@ export function OutagesPageClient() {
             value={presetName}
             onChange={(e) => setPresetName(e.target.value)}
           />
-          <Button
-            variant="outline"
-            className="text-xs h-7 px-2"
-            disabled={!presetName.trim()}
-            onClick={() => {
-              savePreset({ name: presetName.trim(), severity: state.severity, status: state.status });
-              setPresetName("");
-            }}
-          >
+          <Button variant="outline" className="text-xs h-7 px-2" disabled={!presetName.trim()} onClick={() => { savePreset({ name: presetName.trim(), severity: state.severity, status: state.status }); setPresetName(""); }}>
             Save preset
           </Button>
         </div>
       </div>
 
+      {/* Filters */}
       <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
         <label className="space-y-2 text-sm">
           <span className="font-medium text-slate-700">Severity</span>
-          <select
-            className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-            value={state.severity ?? ""}
-            onChange={(event) => actions.setSeverity(event.target.value || undefined)}
-          >
+          <select className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm" value={state.severity ?? ""} onChange={(e) => actions.setSeverity(e.target.value || undefined)}>
             <option value="">All severities</option>
             <option value="critical">Critical</option>
             <option value="high">High</option>
@@ -407,51 +243,42 @@ export function OutagesPageClient() {
             <option value="low">Low</option>
           </select>
         </label>
-
         <label className="space-y-2 text-sm">
           <span className="font-medium text-slate-700">Status</span>
-          <select
-            className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-            value={state.status ?? ""}
-            onChange={(event) => actions.setStatus(event.target.value || undefined)}
-          >
+          <select className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm" value={state.status ?? ""} onChange={(e) => actions.setStatus(e.target.value || undefined)}>
             <option value="">All statuses</option>
             <option value="open">Open</option>
             <option value="resolved">Resolved</option>
           </select>
         </label>
-
         <label className="space-y-2 text-sm">
-          <span className="font-medium text-slate-700">Rows per page</span>
-          <select
-            className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-            value={state.page_size}
-            onChange={(event) => actions.setPageSize(Number(event.target.value))}
-          >
-            {[10, 20, 50].map((size) => (
-              <option key={size} value={size}>
-                {size}
-              </option>
-            ))}
+          <span className="font-medium text-slate-700">Sort by</span>
+          <select className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm" value={state.sort_field ?? ""} onChange={(e) => { const f = e.target.value as SortField; f ? actions.setSort(f, state.sort_order) : actions.clearSort(); }}>
+            <option value="">Default order</option>
+            {SORT_FIELDS.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
           </select>
         </label>
+        <label className="space-y-2 text-sm">
+          <span className="font-medium text-slate-700">Direction</span>
+          <select className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm" value={state.sort_order} disabled={!state.sort_field} onChange={(e) => { if (state.sort_field) actions.setSort(state.sort_field, e.target.value as SortOrder); }}>
+            <option value="desc">Descending</option>
+            <option value="asc">Ascending</option>
+          </select>
+        </label>
+      </div>
 
-        <div className="rounded-lg bg-slate-50 p-4">
-          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
-            Result count
-          </p>
-          <p className="mt-2 text-2xl font-semibold text-slate-900">{totalItems}</p>
-          <p className="mt-1 text-sm text-slate-500">
-            Page {state.page} of {totalPages}
-          </p>
-        </div>
+      <div className="flex items-center gap-4">
+        <label className="space-y-1 text-sm">
+          <span className="font-medium text-slate-700">Rows per page</span>
+          <select className="rounded-md border border-slate-200 bg-white px-3 py-2 text-sm" value={state.page_size} onChange={(e) => actions.setPageSize(Number(e.target.value))}>
+            {[10, 20, 50].map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </label>
+        <span className="text-sm text-slate-500 ml-auto">{totalItems} results · Page {state.page} of {totalPages}</span>
       </div>
 
       {outages.length === 0 ? (
-        <RouteEmptyState
-          title="No outages found"
-          description="Try widening your filters or lowering the severity restriction."
-        />
+        <RouteEmptyState title="No outages found" description="Try widening your filters or lowering the severity restriction." />
       ) : (
         <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
           <DataTable
@@ -462,249 +289,29 @@ export function OutagesPageClient() {
             density={density}
             onDensityChange={setDensity}
           />
-
-          <div className="flex flex-col gap-3 border-t border-slate-100 pt-4 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between">
-            <span>
-              Showing {(state.page - 1) * state.page_size + 1}-
-              {Math.min(state.page * state.page_size, totalItems)} of {totalItems}
-            </span>
-
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                onClick={() => actions.setPage(state.page - 1)}
-                disabled={state.page <= 1}
-              >
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                onClick={() => actions.setPage(state.page + 1)}
-                disabled={state.page >= totalPages}
-              >
-                Next
-              </Button>
-            {/* FE-058: Search bar */}
-            <form
-                className="flex items-center gap-2"
-                onSubmit={(e) => {
-                    e.preventDefault();
-                    actions.setSearch(searchInput.trim() || undefined);
-                }}
-            >
-                <input
-                    type="search"
-                    className="flex-1 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                    placeholder="Search by site ID, site name, or outage ID…"
-                    value={searchInput}
-                    onChange={(e) => setSearchInput(e.target.value)}
-                    aria-label="Search outages"
-                />
-                <Button type="submit" variant="outline" className="text-sm">
-                    Search
-                </Button>
-                {state.search && (
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        className="text-sm text-slate-500"
-                        onClick={() => {
-                            setSearchInput("");
-                            actions.setSearch(undefined);
-                        }}
-                    >
-                        Clear
-                    </Button>
-                )}
-            </form>
-
-            {/* Filter presets */}
-            <div className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-                <span className="text-xs font-medium text-slate-500 uppercase tracking-wide">Presets:</span>
-                {presets.map((preset) => (
-                    <div key={preset.name} className="flex items-center gap-1">
-                        <button
-                            className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100"
-                            onClick={() => {
-                                actions.setSeverity(preset.severity);
-                                actions.setStatus(preset.status);
-                            }}
-                        >
-                            {preset.name}
-                        </button>
-                        <button
-                            className="text-slate-400 hover:text-red-500 text-xs"
-                            onClick={() => deletePreset(preset.name)}
-                            aria-label={`Delete preset ${preset.name}`}
-                        >
-                            ×
-                        </button>
-                    </div>
-                ))}
-                <div className="ml-auto flex items-center gap-2">
-                    <input
-                        className="rounded-md border border-slate-200 px-2 py-1 text-xs"
-                        placeholder="Preset name"
-                        value={presetName}
-                        onChange={(e) => setPresetName(e.target.value)}
-                    />
-                    <Button
-                        variant="outline"
-                        className="text-xs h-7 px-2"
-                        disabled={!presetName.trim()}
-                        onClick={() => {
-                            savePreset({ name: presetName.trim(), severity: state.severity, status: state.status });
-                            setPresetName("");
-                        }}
-                    >
-                        Save preset
-                    </Button>
-                </div>
-            </div>
-
-            <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
-                <label className="space-y-2 text-sm">
-                    <span className="font-medium text-slate-700">Severity</span>
-                    <select
-                        className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        value={state.severity ?? ""}
-                        onChange={(event) => actions.setSeverity(event.target.value || undefined)}
-                    >
-                        <option value="">All severities</option>
-                        <option value="critical">Critical</option>
-                        <option value="high">High</option>
-                        <option value="medium">Medium</option>
-                        <option value="low">Low</option>
-                    </select>
-                </label>
-
-                <label className="space-y-2 text-sm">
-                    <span className="font-medium text-slate-700">Status</span>
-                    <select
-                        className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        value={state.status ?? ""}
-                        onChange={(event) => actions.setStatus(event.target.value || undefined)}
-                    >
-                        <option value="">All statuses</option>
-                        <option value="open">Open</option>
-                        <option value="resolved">Resolved</option>
-                    </select>
-                </label>
-
-                {/* FE-059: Sort controls */}
-                <label className="space-y-2 text-sm">
-                    <span className="font-medium text-slate-700">Sort by</span>
-                    <select
-                        className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        value={state.sort_field ?? ""}
-                        onChange={(e) => {
-                            const field = e.target.value as SortField;
-                            if (field) {
-                                actions.setSort(field, state.sort_order);
-                            } else {
-                                actions.clearSort();
-                            }
-                        }}
-                    >
-                        <option value="">Default order</option>
-                        {SORT_FIELDS.map((f) => (
-                            <option key={f.value} value={f.value}>{f.label}</option>
-                        ))}
-                    </select>
-                </label>
-
-                <label className="space-y-2 text-sm">
-                    <span className="font-medium text-slate-700">Sort direction</span>
-                    <select
-                        className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        value={state.sort_order}
-                        disabled={!state.sort_field}
-                        onChange={(e) => {
-                            if (state.sort_field) {
-                                actions.setSort(state.sort_field, e.target.value as SortOrder);
-                            }
-                        }}
-                    >
-                        <option value="desc">Descending</option>
-                        <option value="asc">Ascending</option>
-                    </select>
-                </label>
-            </div>
-
-            <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
-                <label className="space-y-2 text-sm">
-                    <span className="font-medium text-slate-700">Rows per page</span>
-                    <select
-                        className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        value={state.page_size}
-                        onChange={(event) => actions.setPageSize(Number(event.target.value))}
-                    >
-                        {[10, 20, 50].map((size) => (
-                            <option key={size} value={size}>
-                                {size}
-                            </option>
-                        ))}
-                    </select>
-                </label>
-
-                <div className="rounded-lg bg-slate-50 p-4 md:col-start-4">
-                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                        Result count
-                    </p>
-                    <p className="mt-2 text-2xl font-semibold text-slate-900">{totalItems}</p>
-                    <p className="mt-1 text-sm text-slate-500">
-                        Page {state.page} of {totalPages}
-                    </p>
-                </div>
-            </div>
+          <div className="flex items-center justify-end gap-2 border-t border-slate-100 pt-4">
+            <Button variant="outline" onClick={() => actions.setPage(state.page - 1)} disabled={state.page <= 1}>Previous</Button>
+            <Button variant="outline" onClick={() => actions.setPage(state.page + 1)} disabled={state.page >= totalPages}>Next</Button>
           </div>
         </div>
       )}
 
-      {/* Delete confirmation dialog */}
       {pendingDelete && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="delete-dialog-title"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-        >
+        <div role="dialog" aria-modal="true" aria-labelledby="delete-dialog-title" className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
           <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl space-y-4">
-            <h2 id="delete-dialog-title" className="text-lg font-semibold text-slate-900">
-              Delete outage?
-            </h2>
+            <h2 id="delete-dialog-title" className="text-lg font-semibold text-slate-900">Delete outage?</h2>
             <p className="text-sm text-slate-600">
-              This will permanently delete outage{" "}
-              <span className="font-medium">{pendingDelete.id}</span> (
-              {pendingDelete.site_name}). This action cannot be undone.
+              This will permanently delete outage <span className="font-medium">{pendingDelete.id}</span> ({pendingDelete.site_name}). This action cannot be undone.
             </p>
             {deleteError && (
               <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
                 {deleteError}{" "}
-                <button
-                  className="underline font-medium"
-                  onClick={handleDeleteConfirm}
-                  disabled={deleting}
-                >
-                  Retry
-                </button>
+                <button className="underline font-medium" onClick={handleDeleteConfirm} disabled={deleting}>Retry</button>
               </div>
             )}
             <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                onClick={() => { setPendingDelete(null); setDeleteError(null); }}
-                disabled={deleting}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={handleDeleteConfirm}
-                disabled={deleting}
-              >
-                {deleting ? "Deleting…" : "Delete"}
-              </Button>
+              <Button variant="outline" onClick={() => { setPendingDelete(null); setDeleteError(null); }} disabled={deleting}>Cancel</Button>
+              <Button variant="destructive" onClick={handleDeleteConfirm} disabled={deleting}>{deleting ? "Deleting…" : "Delete"}</Button>
             </div>
           </div>
         </div>

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 
 import { api } from "@/lib/api";
+import { explorerLink } from "@/lib/explorer";
 import { useSession } from "@/hooks/useSession";
 
 type AuthUser = {
@@ -658,7 +659,11 @@ export default function SettingsPage() {
                   <div className="flex justify-between gap-4">
                     <dt>Address</dt>
                     <dd className="break-all text-right font-medium text-slate-900">
-                      {wallet.public_key}
+                      {explorerLink("account", wallet.public_key) ? (
+                        <a href={explorerLink("account", wallet.public_key)!} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                          {wallet.public_key}
+                        </a>
+                      ) : wallet.public_key}
                     </dd>
                   </div>
                   <div className="flex justify-between gap-4">

--- a/src/components/dashboard/sla-dashboard-view.tsx
+++ b/src/components/dashboard/sla-dashboard-view.tsx
@@ -2,14 +2,14 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+
 import KPICard from "@/components/dashboard/KPICard";
 import PenaltiesRewardsChart from "@/components/dashboard/PenaltiesRewardsChart";
 import SLATrendChart from "@/components/dashboard/SLATrendChart";
 import { RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
 import { fetchDashboardMetrics, type DashboardFilters } from "@/services/dashboardService";
 import type { DashboardMetrics, TrendPoint } from "@/types/dashboard";
-import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
 
 function exportSnapshot(metrics: DashboardMetrics, label = "dashboard") {
   const snapshot = {
@@ -37,43 +37,27 @@ function delta(a: number, b: number) {
 const SEVERITIES = ["", "low", "medium", "high", "critical"];
 
 export default function SLADashboardView() {
-  const [compareMode, setCompareMode] = useState(false);
-
-  const primary = useQuery<DashboardMetrics>({
-    queryKey: ["dashboard-metrics"],
-    queryFn: fetchDashboardMetrics,
-    staleTime: 30_000,
-  });
-
-  // Second window: same endpoint, separate cache key, only fetched when compare mode is on
-  const secondary = useQuery<DashboardMetrics>({
-    queryKey: ["dashboard-metrics-compare"],
-    queryFn: fetchDashboardMetrics,
-    staleTime: 30_000,
-    enabled: compareMode,
-  });
-
-  if (primary.isLoading) {
   const router = useRouter();
+  const [compareMode, setCompareMode] = useState(false);
   const [filters, setFilters] = useState<DashboardFilters>({});
-
-  const {
-    data: metrics,
-    isLoading,
-    isError,
-    refetch,
-    dataUpdatedAt,
-  } = useQuery<DashboardMetrics>({
-    queryKey: ["dashboard-metrics", filters],
-    queryFn: () => fetchDashboardMetrics(filters),
-    staleTime: 30_000,
-  });
 
   function set(key: keyof DashboardFilters, value: string) {
     setFilters((f) => ({ ...f, [key]: value || undefined }));
   }
 
-  // FE-076: drilldown — navigate to outages/payments with filter context
+  const primary = useQuery<DashboardMetrics>({
+    queryKey: ["dashboard-metrics", filters],
+    queryFn: () => fetchDashboardMetrics(filters),
+    staleTime: 30_000,
+  });
+
+  const secondary = useQuery<DashboardMetrics>({
+    queryKey: ["dashboard-metrics-compare"],
+    queryFn: () => fetchDashboardMetrics(),
+    staleTime: 30_000,
+    enabled: compareMode,
+  });
+
   function onTrendClick(point: TrendPoint) {
     const params = new URLSearchParams();
     if (point.period) params.set("date_from", point.period);
@@ -96,7 +80,7 @@ export default function SLADashboardView() {
     router.push(`/payments?${params.toString()}`);
   }
 
-  if (isLoading) {
+  if (primary.isLoading) {
     return (
       <RouteLoadingState
         title="Loading dashboard"
@@ -121,7 +105,6 @@ export default function SLADashboardView() {
   const lastUpdated = primary.dataUpdatedAt
     ? new Date(primary.dataUpdatedAt).toLocaleString()
     : "Not synced yet";
-
   const cmp = compareMode && secondary.data ? secondary.data : null;
 
   return (
@@ -129,83 +112,41 @@ export default function SLADashboardView() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-1">
           <h1 className="text-2xl font-bold text-gray-800">SLA Analytics Dashboard</h1>
-          <p className="text-sm text-gray-500">
-            Live backend analytics for compliance, payouts, and trend movement.
-          </p>
+          <p className="text-sm text-gray-500">Live backend analytics for compliance, payouts, and trend movement.</p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-gray-400">
-            Updated {lastUpdated}
-          </span>
+          <span className="text-xs uppercase tracking-wide text-gray-400">Updated {lastUpdated}</span>
           <button
             onClick={() => setCompareMode((v) => !v)}
-            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
-              compareMode
-                ? "border-blue-400 bg-blue-50 text-blue-700"
-                : "border-gray-200 text-gray-600 hover:bg-gray-50"
-            }`}
+            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${compareMode ? "border-blue-400 bg-blue-50 text-blue-700" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
           >
             {compareMode ? "Exit Compare" : "Compare"}
           </button>
-          <button
-            onClick={() => exportSnapshot(metrics)}
-            className="rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
-          >
-            Export
-          </button>
-          <button
-            onClick={() => void primary.refetch()}
-            className="rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
-          >
-            Refresh
-          </button>
+          <button onClick={() => exportSnapshot(metrics)} className="rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50">Export</button>
+          <button onClick={() => void primary.refetch()} className="rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50">Refresh</button>
         </div>
       </div>
 
-      {compareMode && secondary.isLoading ? (
-        <p className="text-sm text-gray-400">Loading comparison window…</p>
-      ) : null}
-      {/* FE-074 + FE-075: date range + severity/site filters */}
+      {compareMode && secondary.isLoading ? <p className="text-sm text-gray-400">Loading comparison window…</p> : null}
+
       <div className="grid grid-cols-2 gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-4">
         <label className="space-y-1 text-xs">
           <span className="font-medium text-slate-600">From</span>
-          <input
-            type="date"
-            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
-            value={filters.date_from ?? ""}
-            onChange={(e) => set("date_from", e.target.value)}
-          />
+          <input type="date" className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm" value={filters.date_from ?? ""} onChange={(e) => set("date_from", e.target.value)} />
         </label>
         <label className="space-y-1 text-xs">
           <span className="font-medium text-slate-600">To</span>
-          <input
-            type="date"
-            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
-            value={filters.date_to ?? ""}
-            onChange={(e) => set("date_to", e.target.value)}
-          />
+          <input type="date" className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm" value={filters.date_to ?? ""} onChange={(e) => set("date_to", e.target.value)} />
         </label>
         <label className="space-y-1 text-xs">
           <span className="font-medium text-slate-600">Severity</span>
-          <select
-            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
-            value={filters.severity ?? ""}
-            onChange={(e) => set("severity", e.target.value)}
-          >
-            {SEVERITIES.map((s) => (
-              <option key={s} value={s}>{s || "All"}</option>
-            ))}
+          <select className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm" value={filters.severity ?? ""} onChange={(e) => set("severity", e.target.value)}>
+            {SEVERITIES.map((s) => <option key={s} value={s}>{s || "All"}</option>)}
           </select>
         </label>
         <label className="space-y-1 text-xs">
           <span className="font-medium text-slate-600">Site</span>
-          <input
-            type="text"
-            placeholder="e.g. site-a"
-            className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm"
-            value={filters.site ?? ""}
-            onChange={(e) => set("site", e.target.value)}
-          />
+          <input type="text" placeholder="e.g. site-a" className="w-full rounded border border-slate-200 bg-white px-2 py-1.5 text-sm" value={filters.site ?? ""} onChange={(e) => set("site", e.target.value)} />
         </label>
       </div>
 
@@ -241,20 +182,13 @@ export default function SLADashboardView() {
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        {/* FE-076: pass drilldown handlers */}
         <SLATrendChart data={metrics.trends} onPointClick={onTrendClick} />
-        <PenaltiesRewardsChart
-          data={metrics.trends}
-          onPenaltyClick={onPenaltyClick}
-          onRewardClick={onRewardClick}
-        />
+        <PenaltiesRewardsChart data={metrics.trends} onPenaltyClick={onPenaltyClick} onRewardClick={onRewardClick} />
       </div>
 
       {cmp && cmp.trends.length > 0 ? (
         <div>
-          <p className="mb-3 text-sm font-semibold text-gray-500 uppercase tracking-wide">
-            Comparison Window
-          </p>
+          <p className="mb-3 text-sm font-semibold text-gray-500 uppercase tracking-wide">Comparison Window</p>
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             <SLATrendChart data={cmp.trends} />
             <PenaltiesRewardsChart data={cmp.trends} />
@@ -263,9 +197,7 @@ export default function SLADashboardView() {
       ) : null}
 
       {compareMode && cmp && cmp.trends.length === 0 ? (
-        <p className="rounded-lg bg-yellow-50 px-4 py-2 text-sm text-yellow-700">
-          No data available for the comparison window.
-        </p>
+        <p className="rounded-lg bg-yellow-50 px-4 py-2 text-sm text-yellow-700">No data available for the comparison window.</p>
       ) : null}
     </div>
   );

--- a/src/components/payments/payment-detail-drawer.tsx
+++ b/src/components/payments/payment-detail-drawer.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 
 import { RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
+import { useToast } from "@/components/ui/toast";
+import { explorerLink } from "@/lib/explorer";
 import { fetchPayment, retryPayment, reconcilePayment } from "@/services/paymentService";
 import type { Payment } from "@/types/payment";
 
@@ -24,6 +26,7 @@ export function PaymentDetailDrawer({ paymentId, onClose }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [actionState, setActionState] = useState<{ type: "retry" | "reconcile"; status: "loading" | "success" | "error"; message?: string } | null>(null);
+  const toast = useToast();
 
   useEffect(() => {
     if (!paymentId) { setPayment(null); return; }
@@ -46,13 +49,13 @@ export function PaymentDetailDrawer({ paymentId, onClose }: Props) {
         ? await retryPayment(payment.id)
         : await reconcilePayment(payment.id);
       setPayment(updated);
-      setActionState({ type, status: "success", message: `${type === "retry" ? "Retry" : "Reconciliation"} succeeded.` });
+      const msg = `${type === "retry" ? "Retry" : "Reconciliation"} succeeded.`;
+      setActionState({ type, status: "success", message: msg });
+      toast(msg, "success");
     } catch (err) {
-      setActionState({
-        type,
-        status: "error",
-        message: err instanceof Error ? err.message : `${type} failed. Please try again.`,
-      });
+      const msg = err instanceof Error ? err.message : `${type} failed. Please try again.`;
+      setActionState({ type, status: "error", message: msg });
+      toast(msg, "error");
     }
   }
 
@@ -125,9 +128,21 @@ export function PaymentDetailDrawer({ paymentId, onClose }: Props) {
                     </span>
                   }
                 />
-                <Row label="From" value={payment.from_address} mono />
-                <Row label="To" value={payment.to_address} mono />
-                <Row label="Transaction Hash" value={payment.transaction_hash} mono />
+                <Row label="From" value={
+                  explorerLink("account", payment.from_address)
+                    ? <a href={explorerLink("account", payment.from_address)!} target="_blank" rel="noopener noreferrer" className="font-mono text-xs text-blue-600 hover:underline break-all">{payment.from_address}</a>
+                    : <span className="font-mono text-xs">{payment.from_address}</span>
+                } />
+                <Row label="To" value={
+                  explorerLink("account", payment.to_address)
+                    ? <a href={explorerLink("account", payment.to_address)!} target="_blank" rel="noopener noreferrer" className="font-mono text-xs text-blue-600 hover:underline break-all">{payment.to_address}</a>
+                    : <span className="font-mono text-xs">{payment.to_address}</span>
+                } />
+                <Row label="Transaction Hash" value={
+                  explorerLink("tx", payment.transaction_hash)
+                    ? <a href={explorerLink("tx", payment.transaction_hash)!} target="_blank" rel="noopener noreferrer" className="font-mono text-xs text-blue-600 hover:underline break-all">{payment.transaction_hash}</a>
+                    : <span className="font-mono text-xs">{payment.transaction_hash || "—"}</span>
+                } />
                 <Row label="Created" value={new Date(payment.created_at).toLocaleString()} />
                 {payment.confirmed_at && (
                   <Row label="Confirmed" value={new Date(payment.confirmed_at).toLocaleString()} />

--- a/src/components/payments/payments-view.tsx
+++ b/src/components/payments/payments-view.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { PaymentDetailDrawer } from "@/components/payments/payment-detail-drawer";
 import { RouteEmptyState, RouteErrorState, RouteLoadingState } from "@/components/ui/route-state";
@@ -25,14 +26,28 @@ const typeStyles: Record<string, string> = {
 };
 
 export default function PaymentsView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [data, setData] = useState<PaginatedPayments | null>(null);
   const [page, setPage] = useState(1);
   const [perPage] = useState(10);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedPaymentId, setSelectedPaymentId] = useState<string | null>(null);
+  const [selectedPaymentId, setSelectedPaymentId] = useState<string | null>(
+    () => searchParams.get("paymentId")
+  );
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+
+  // Sync drawer open/close with URL
+  function openDrawer(id: string) {
+    setSelectedPaymentId(id);
+    router.replace(`/payments?paymentId=${id}`, { scroll: false });
+  }
+  function closeDrawer() {
+    setSelectedPaymentId(null);
+    router.replace("/payments", { scroll: false });
+  }
 
   // FE-069: filter state
   const [statusFilter, setStatusFilter] = useState("");
@@ -242,7 +257,7 @@ export default function PaymentsView() {
               <tr
                 key={payment.id}
                 className="border-t transition-colors hover:bg-gray-50 cursor-pointer"
-                onClick={() => setSelectedPaymentId(payment.id)}
+                onClick={() => openDrawer(payment.id)}
               >
                 {/* FE-070: outage link in table */}
                 <td className={`${cell} font-mono text-gray-700`}>
@@ -293,7 +308,7 @@ export default function PaymentsView() {
 
       <PaymentDetailDrawer
         paymentId={selectedPaymentId}
-        onClose={() => setSelectedPaymentId(null)}
+        onClose={closeDrawer}
       />
     </div>
   );

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+
+type ToastVariant = "success" | "error" | "info";
+
+interface Toast {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  toast: (message: string, variant?: ToastVariant) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const counter = useRef(0);
+
+  const toast = useCallback((message: string, variant: ToastVariant = "info") => {
+    const id = ++counter.current;
+    setToasts((prev) => [...prev, { id, message, variant }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 4000);
+  }, []);
+
+  const variantClass: Record<ToastVariant, string> = {
+    success: "border-emerald-200 bg-emerald-50 text-emerald-800",
+    error: "border-red-200 bg-red-50 text-red-700",
+    info: "border-slate-200 bg-white text-slate-800",
+  };
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <div
+        role="region"
+        aria-live="polite"
+        aria-label="Notifications"
+        className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2"
+      >
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`flex items-center justify-between gap-4 rounded-lg border px-4 py-3 text-sm shadow-md ${variantClass[t.variant]}`}
+          >
+            <span>{t.message}</span>
+            <button
+              aria-label="Dismiss"
+              onClick={() => setToasts((prev) => prev.filter((x) => x.id !== t.id))}
+              className="shrink-0 opacity-60 hover:opacity-100"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx.toast;
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,9 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { api, clearTokens, getAccessToken, setTokens } from "@/lib/api";
 import { useEffect, useRef, useState } from "react";
-import { api } from "@/lib/api";
+import { api, clearTokens, getAccessToken, setTokens } from "@/lib/api";
 
 export type SessionState = "loading" | "authenticated" | "unauthenticated";
 

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,0 +1,14 @@
+const NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "testnet") as "mainnet" | "testnet";
+
+const BASE: Record<typeof NETWORK, string> = {
+  mainnet: "https://stellar.expert/explorer/public",
+  testnet: "https://stellar.expert/explorer/testnet",
+};
+
+export function explorerLink(type: "account" | "tx", value: string | null | undefined): string | null {
+  if (!value || value.trim() === "") return null;
+  const base = BASE[NETWORK] ?? BASE.testnet;
+  return `${base}/${type}/${value}`;
+}
+
+export const STELLAR_NETWORK = NETWORK;


### PR DESCRIPTION
closes #133, 
closes #134, 
closes #135, 
closes #136

- **FE-089**: `ToastProvider` + `useToast` hook in `src/components/ui/toast.tsx`, wired into layout. Toast on outage resolve/edit and payment retry/reconcile.
- **FE-090**: `explorerLink()` helper in `src/lib/explorer.ts`. Explorer links on payment from/to/tx hash and settings wallet address. Network via `NEXT_PUBLIC_STELLAR_NETWORK`.
- **FE-091**: Payments view reads `?paymentId` on load and syncs URL on open/close.
- **FE-092**: `docs/api-types.md` — manual sync strategy, high-risk model table, OpenAPI codegen path.

Also fixed 4 pre-existing bad-merge files that were blocking the build.