### PR TITLE
fe-085-088: React Query hook, mutation tests, focus trap, responsive utils

### DIFF
--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { RefObject, useEffect } from "react";
+
+const FOCUSABLE =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+/**
+ * Traps focus within `containerRef` while `open` is true.
+ * Restores focus to the element that was active when the trap engaged.
+ * Closes on Escape via `onClose`.
+ */
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  open: boolean,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    if (!open) return;
+
+    const trigger = document.activeElement as HTMLElement | null;
+    const container = containerRef.current;
+
+    // Move focus into the container on open
+    const firstFocusable = container?.querySelector<HTMLElement>(FOCUSABLE);
+    firstFocusable?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!container) return;
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      trigger?.focus();
+    };
+  }, [open, containerRef, onClose]);
+}

--- a/src/hooks/useSlaConfig.test.tsx
+++ b/src/hooks/useSlaConfig.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { api } from "@/lib/api";
+import { useSlaConfig, useUpdateSlaConfig } from "@/hooks/useSlaConfig";
+
+jest.mock("@/lib/api");
+const mockedApi = api as jest.Mocked<typeof api>;
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useSlaConfig cache invalidation", () => {
+  let client: QueryClient;
+
+  beforeEach(() => {
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  it("populates cache after successful fetch", async () => {
+    mockedApi.get.mockResolvedValueOnce({
+      data: { critical: { threshold_minutes: 30, penalty_per_minute: 5, reward_base: 100 } },
+    });
+
+    const { result } = renderHook(() => useSlaConfig(), { wrapper: makeWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].severity).toBe("critical");
+  });
+
+  it("updates cache entry after mutation without refetch", async () => {
+    const initial = [{ severity: "high", threshold_minutes: 60, penalty_per_minute: 2, reward_base: 50 }];
+    client.setQueryData(["sla", "config"], initial);
+
+    mockedApi.put.mockResolvedValueOnce({
+      data: { threshold_minutes: 45, penalty_per_minute: 3, reward_base: 50 },
+    });
+
+    const { result } = renderHook(() => useUpdateSlaConfig(), { wrapper: makeWrapper(client) });
+    result.current.mutate({ severity: "high", threshold_minutes: 45, penalty_per_minute: 3, reward_base: 50 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = client.getQueryData<typeof initial>(["sla", "config"]);
+    expect(cached?.[0].threshold_minutes).toBe(45);
+    expect(mockedApi.get).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSlaConfig.ts
+++ b/src/hooks/useSlaConfig.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+type Severity = "critical" | "high" | "medium" | "low";
+
+type SLASeverityConfig = {
+  threshold_minutes: number;
+  penalty_per_minute: number;
+  reward_base: number;
+};
+
+type SLAConfigMap = Record<string, SLASeverityConfig>;
+
+export type EditableConfig = SLASeverityConfig & { severity: Severity };
+
+const SEVERITY_ORDER: Record<Severity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+const SLA_CONFIG_KEY = ["sla", "config"] as const;
+
+export function useSlaConfig() {
+  return useQuery({
+    queryKey: SLA_CONFIG_KEY,
+    queryFn: async () => {
+      const { data } = await api.get<SLAConfigMap>("/sla/config");
+      return Object.entries(data)
+        .map(([severity, config]) => ({ severity: severity as Severity, ...config }))
+        .sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+    },
+  });
+}
+
+export function useUpdateSlaConfig() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ severity, ...body }: EditableConfig) => {
+      const { data } = await api.put<SLASeverityConfig>(`/sla/config/${severity}`, body);
+      return { severity, ...data } as EditableConfig;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<EditableConfig[]>(SLA_CONFIG_KEY, (prev) =>
+        prev?.map((c) => (c.severity === updated.severity ? updated : c)) ?? [],
+      );
+    },
+  });
+}

--- a/src/lib/responsive.ts
+++ b/src/lib/responsive.ts
@@ -1,0 +1,44 @@
+/**
+ * Responsive layout utilities for dashboard, outages, and payments views.
+ * Provides Tailwind class helpers that enforce consistent narrow-viewport behaviour.
+ */
+
+/** Full-bleed scrollable wrapper for dense tables on small screens. */
+export const tableScrollWrapper = "w-full overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0";
+
+/** Responsive grid for dashboard stat cards: 1 col → 2 col → 4 col. */
+export const statCardGrid = "grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4";
+
+/** Stack filter controls vertically on mobile, row on sm+. */
+export const filterBarLayout = "flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center";
+
+/** Drawer width: full on mobile, fixed sidebar on sm+. */
+export const drawerWidth = "w-full sm:w-[420px]";
+
+/** Clamp long text in table cells to prevent layout blowout. */
+export const tableCellText = "max-w-[160px] truncate sm:max-w-none";
+
+type Breakpoint = "sm" | "md" | "lg" | "xl";
+
+const BREAKPOINTS: Record<Breakpoint, number> = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+};
+
+/** Returns true when the viewport is narrower than the given breakpoint. */
+export function isBelowBreakpoint(bp: Breakpoint): boolean {
+  if (typeof window === "undefined") return false;
+  return window.innerWidth < BREAKPOINTS[bp];
+}
+
+/** Joins class strings, filtering falsy values. */
+export function cx(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+/** Returns responsive padding classes scaled by density. */
+export function cellPadding(compact: boolean): string {
+  return compact ? "px-2 py-1 text-xs" : "px-3 py-2 text-sm";
+}


### PR DESCRIPTION
Closes #129, closes #130, closes #131, closes #132

- **#129** – Adds `useSlaConfig` and `useUpdateSlaConfig` hooks to replace manual `useEffect`/`useState` fetch state in the SLA config page with React Query, giving consistent caching and retry behaviour.
- **#130** – Adds `useSlaConfig.test.tsx` with cache-population and optimistic-update tests that assert cache state after mutations, not just API call success.
- **#131** – Adds `useFocusTrap` hook that traps Tab/Shift-Tab within a container, closes on Escape, and restores focus to the trigger element on close.
- **#132** – Adds `src/lib/responsive.ts` with Tailwind class constants and helpers (`tableScrollWrapper`, `statCardGrid`, `filterBarLayout`, `drawerWidth`, `cellPadding`) for consistent narrow-viewport behaviour across dashboard, outages, and payments views.