### PR TITLE
Letter

### DIFF
--- a/src/features/outages/components/Dry.tsx
+++ b/src/features/outages/components/Dry.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { getOutages } from "@/services/outages";
+import type { Outage } from "@/types/outages";
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Failed to load outages";
+}
+
+const PRESETS_KEY = "outage_filter_presets";
+
+export interface FilterPreset {
+  name: string;
+  severity?: string;
+  status?: string;
+}
+
+export function useFilterPresets() {
+  const [presets, setPresets] = useState<FilterPreset[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(PRESETS_KEY) ?? "[]") as FilterPreset[];
+    } catch {
+      return [];
+    }
+  });
+
+  function savePreset(preset: FilterPreset) {
+    setPresets((prev) => {
+      const next = [...prev.filter((p) => p.name !== preset.name), preset];
+      localStorage.setItem(PRESETS_KEY, JSON.stringify(next));
+      return next;
+    });
+  }
+
+  function deletePreset(name: string) {
+    setPresets((prev) => {
+      const next = prev.filter((p) => p.name !== name);
+      localStorage.setItem(PRESETS_KEY, JSON.stringify(next));
+      return next;
+    });
+  }
+
+  return { presets, savePreset, deletePreset };
+}
+
+export type SortField = "detected_at" | "severity" | "status";
+export type SortOrder = "asc" | "desc";
+
+const VALID_SORT_FIELDS: SortField[] = ["detected_at", "severity", "status"];
+const VALID_SORT_ORDERS: SortOrder[] = ["asc", "desc"];
+
+function parseSortField(v: string | null): SortField | undefined {
+  return VALID_SORT_FIELDS.includes(v as SortField) ? (v as SortField) : undefined;
+}
+
+function parseSortOrder(v: string | null): SortOrder {
+  return VALID_SORT_ORDERS.includes(v as SortOrder) ? (v as SortOrder) : "desc";
+}
+
+// Existing state manager — extended with search + sort + full URL sync (FE-058, FE-059, FE-060)
+export function useOutagesTableState() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  const page = Math.max(1, Number(params?.get("page") ?? 1));
+  const pageSize = Number(params?.get("page_size") ?? 10);
+  const severity = params?.get("severity") ?? undefined;
+  const status = params?.get("status") ?? undefined;
+  // FE-058: search query
+  const search = params?.get("search") ?? undefined;
+  // FE-059: sort field + order
+  const sortField = parseSortField(params?.get("sort_field") ?? null);
+  const sortOrder = parseSortOrder(params?.get("sort_order") ?? null);
+
+  function setParam(key: string, value?: string) {
+    const next = new URLSearchParams(params?.toString() ?? "");
+    if (value) {
+      next.set(key, value);
+    } else {
+      next.delete(key);
+    }
+    router.push(`?${next.toString()}`);
+  }
+
+  function setMultiParam(updates: Record<string, string | undefined>) {
+    const next = new URLSearchParams(params?.toString() ?? "");
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+    }
+    router.push(`?${next.toString()}`);
+  }
+
+  function setPage(nextPage: number) {
+    setParam("page", String(Math.max(1, nextPage)));
+  }
+
+  function setPageSize(nextPageSize: number) {
+    setMultiParam({ page_size: String(nextPageSize), page: "1" });
+  }
+
+  function setSeverity(nextSeverity?: string) {
+    setMultiParam({ severity: nextSeverity, page: "1" });
+  }
+
+  function setStatus(nextStatus?: string) {
+    setMultiParam({ status: nextStatus, page: "1" });
+  }
+
+  // FE-058
+  function setSearch(nextSearch?: string) {
+    setMultiParam({ search: nextSearch || undefined, page: "1" });
+  }
+
+  // FE-059
+  function setSort(field: SortField, order: SortOrder) {
+    setMultiParam({ sort_field: field, sort_order: order, page: "1" });
+  }
+
+  function clearSort() {
+    setMultiParam({ sort_field: undefined, sort_order: undefined, page: "1" });
+  }
+
+  return {
+    state: {
+      page,
+      page_size: pageSize,
+      severity,
+      status,
+      search,
+      sort_field: sortField,
+      sort_order: sortOrder,
+    },
+    actions: {
+      setParam,
+      setPage,
+      setPageSize,
+      setSeverity,
+      setStatus,
+      setSearch,
+      setSort,
+      clearSort,
+    },
+  };
+}
+
+// New data fetching & polling hook for the Outages list
+export function useOutagesList(
+  page: number,
+  severity?: string,
+  status?: string,
+  pageSize: number = 10,
+  search?: string,
+  sortField?: SortField,
+  sortOrder?: SortOrder,
+) {
+  const [outages, setOutages] = useState<Outage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  
+  const isFetching = useRef(false);
+  const hasOutagesRef = useRef(false);
+
+  useEffect(() => {
+    hasOutagesRef.current = outages.length > 0;
+  }, [outages]);
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+
+    const fetchList = async () => {
+      if (isFetching.current) return;
+      isFetching.current = true;
+
+      try {
+        const data = await getOutages({
+          page,
+          page_size: pageSize,
+          severity,
+          status,
+          search,
+          sort_field: sortField,
+          sort_order: sortOrder,
+        });
+        if (isMounted) {
+          setOutages(data.items);
+          setError(null);
+        }
+      } catch (error: unknown) {
+        if (isMounted && !hasOutagesRef.current) {
+          setError(getErrorMessage(error));
+        }
+      } finally {
+        isFetching.current = false;
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    fetchList();
+
+    // The list page constantly polls every 15 seconds to ensure we 
+    // catch any newly generated incidents as well as updates to existing ones.
+    const intervalId = setInterval(fetchList, 15000);
+
+    return () => {
+      isMounted = false;
+      clearInterval(intervalId);
+    };
+  }, [page, pageSize, severity, status, search, sortField, sortOrder]);
+
+  return { outages, loading, error };
+}

--- a/src/features/outages/components/Letter.tsx
+++ b/src/features/outages/components/Letter.tsx
@@ -1,0 +1,193 @@
+import { useState } from "react";
+
+import { previewSLA } from "@/services/sla";
+import type { Severity } from "@/types/outages";
+import type { SLAResult } from "@/types/sla";
+
+interface ResolveModalProps {
+  outageId: string;
+  siteName: string;
+  severity: Severity;
+  initialMttrMinutes?: number;
+  isOpen: boolean;
+  isResolving: boolean;
+  error?: string | null;
+  onClose: () => void;
+  onConfirmResolve: (mttrMinutes: number) => Promise<void>;
+}
+
+export function ResolveOutageModal({
+  outageId,
+  siteName,
+  severity,
+  initialMttrMinutes,
+  isOpen,
+  isResolving,
+  error,
+  onClose,
+  onConfirmResolve,
+}: ResolveModalProps) {
+  const [mttrInput, setMttrInput] = useState(
+    initialMttrMinutes !== undefined ? initialMttrMinutes.toString() : "",
+  );
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewResult, setPreviewResult] = useState<SLAResult | null>(null);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  async function handleResolve() {
+    const parsed = Number(mttrInput);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      setValidationError("MTTR must be a non-negative number.");
+      return;
+    }
+
+    setValidationError(null);
+    await onConfirmResolve(parsed);
+  }
+
+  async function handlePreview() {
+    const parsed = Number(mttrInput);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      setValidationError("MTTR must be a non-negative number.");
+      return;
+    }
+
+    setValidationError(null);
+    setPreviewError(null);
+    setIsPreviewLoading(true);
+
+    try {
+      const result = await previewSLA({
+        severity,
+        mttr_minutes: parsed,
+      });
+      setPreviewResult(result);
+    } catch (issue) {
+      setPreviewError(issue instanceof Error ? issue.message : "Failed to preview SLA.");
+    } finally {
+      setIsPreviewLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow-xl">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold text-slate-900">Resolve outage</h2>
+          <p className="text-sm text-slate-500">
+            Confirm the MTTR for <span className="font-medium text-slate-700">{siteName}</span> and
+            resolve outage <span className="font-medium text-slate-700">{outageId}</span>.
+          </p>
+        </div>
+
+        <div className="mt-6 space-y-4">
+          <div>
+            <label
+              htmlFor="resolve-outage-mttr"
+              className="mb-2 block text-sm font-medium text-slate-700"
+            >
+              Mean time to resolve (minutes)
+            </label>
+            <input
+              id="resolve-outage-mttr"
+              type="number"
+              min={0}
+              value={mttrInput}
+              onChange={(event) => {
+                setMttrInput(event.target.value);
+                setPreviewResult(null);
+                setPreviewError(null);
+              }}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+              placeholder="Enter MTTR in minutes"
+            />
+          </div>
+
+          {validationError ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+              {validationError}
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+
+          {previewError ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+              {previewError}
+            </div>
+          ) : null}
+
+          {previewResult ? (
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <h3 className="text-sm font-semibold text-slate-900">SLA outcome preview</h3>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-lg bg-white px-3 py-2">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">Status</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">
+                    {previewResult.status}
+                  </div>
+                </div>
+                <div className="rounded-lg bg-white px-3 py-2">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">Rating</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">
+                    {previewResult.rating}
+                  </div>
+                </div>
+                <div className="rounded-lg bg-white px-3 py-2">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">Threshold</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">
+                    {previewResult.threshold_minutes} min
+                  </div>
+                </div>
+                <div className="rounded-lg bg-white px-3 py-2">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">Payout</div>
+                  <div
+                    className={`mt-1 text-sm font-medium ${
+                      previewResult.amount >= 0 ? "text-emerald-600" : "text-red-600"
+                    }`}
+                  >
+                    {previewResult.amount >= 0 ? "+" : ""}
+                    {previewResult.amount} ({previewResult.payment_type})
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={isResolving}
+            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handlePreview}
+            disabled={isResolving || isPreviewLoading}
+            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+          >
+            {isPreviewLoading ? "Previewing..." : "Preview SLA"}
+          </button>
+          <button
+            onClick={handleResolve}
+            disabled={isResolving}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+          >
+            {isResolving ? "Resolving..." : "Confirm resolution"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/outages/components/Rotation.tsx
+++ b/src/features/outages/components/Rotation.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { createContext, useContext, useEffect, useRef, useState, ReactNode } from "react";
+import { api, clearTokens, getAccessToken, setTokens } from "@/lib/api";
+
+export type SessionState = "loading" | "authenticated" | "unauthenticated";
+
+export interface SessionUser {
+  id: string;
+  email: string;
+  role: string;
+  full_name?: string | null;
+  stellar_wallet?: string | null;
+  created_at?: string;
+}
+
+interface SessionContextValue {
+  state: SessionState;
+  user: SessionUser | null;
+  logout: () => Promise<void>;
+  storeSession: (accessToken: string, refreshToken: string, user: SessionUser) => void;
+}
+
+const SessionContext = createContext<SessionContextValue | null>(null);
+
+type SessionMessage =
+  | { type: "logout" }
+  | { type: "authenticated"; user: SessionUser };
+
+const CHANNEL_NAME = "noc_iq_session";
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<SessionState>("loading");
+  const [user, setUser] = useState<SessionUser | null>(null);
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  // Cross-tab sync
+  useEffect(() => {
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channelRef.current = channel;
+    channel.onmessage = (event: MessageEvent<SessionMessage>) => {
+      const msg = event.data;
+      if (msg.type === "logout") {
+        setUser(null);
+        setState("unauthenticated");
+      } else if (msg.type === "authenticated") {
+        setUser(msg.user);
+        setState("authenticated");
+      }
+    };
+    return () => {
+      channel.close();
+      channelRef.current = null;
+    };
+  }, []);
+
+  // Bootstrap session once on mount
+  useEffect(() => {
+    let isMounted = true;
+
+    function handleAuthLogout() {
+      if (isMounted) {
+        setUser(null);
+        setState("unauthenticated");
+      }
+    }
+
+    window.addEventListener("auth:logout", handleAuthLogout);
+
+    if (!getAccessToken()) {
+      setState("unauthenticated");
+      return () => {
+        isMounted = false;
+        window.removeEventListener("auth:logout", handleAuthLogout);
+      };
+    }
+
+    const controller = new AbortController();
+
+    api
+      .get<SessionUser>("/auth/me", { signal: controller.signal } as Parameters<typeof api.get>[1])
+      .then((res) => {
+        if (isMounted) {
+          setUser(res.data);
+          setState("authenticated");
+          channelRef.current?.postMessage({ type: "authenticated", user: res.data } satisfies SessionMessage);
+        }
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string }).name === "CanceledError") return;
+        if (isMounted) {
+          clearTokens();
+          setUser(null);
+          setState("unauthenticated");
+        }
+      });
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+      window.removeEventListener("auth:logout", handleAuthLogout);
+    };
+  }, []);
+
+  function storeSession(accessToken: string, refreshToken: string, sessionUser: SessionUser) {
+    setTokens(accessToken, refreshToken);
+    setUser(sessionUser);
+    setState("authenticated");
+  }
+
+  async function logout() {
+    try {
+      await api.post("/auth/logout");
+    } finally {
+      clearTokens();
+      setUser(null);
+      setState("unauthenticated");
+      channelRef.current?.postMessage({ type: "logout" } satisfies SessionMessage);
+    }
+  }
+
+  return (
+    <SessionContext.Provider value={{ state, user, logout, storeSession }}>
+      {children}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSession(): SessionContextValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) throw new Error("useSession must be used within SessionProvider");
+  return ctx;
+}

--- a/src/features/outages/components/details.tsx
+++ b/src/features/outages/components/details.tsx
@@ -1,0 +1,193 @@
+import { useState } from "react";
+
+import { previewSLA } from "@/services/sla";
+import type { Severity } from "@/types/outages";
+import type { SLAResult } from "@/types/sla";
+
+interface ResolveModalProps {
+  outageId: string;
+  siteName: string;
+  severity: Severity;
+  initialMttrMinutes?: number;
+  isOpen: boolean;
+  isResolving: boolean;
+  error?: string | null;
+  onClose: () => void;
+  onConfirmResolve: (mttrMinutes: number) => Promise<void>;
+}
+
+export function DetailsModal({
+  outageId,
+  siteName,
+  severity,
+  initialMttrMinutes,
+  isOpen,
+  isResolving,
+  error,
+  onClose,
+  onConfirmResolve,
+}: ResolveModalProps) {
+  const [mttrInput, setMttrInput] = useState(
+    initialMttrMinutes !== undefined ? initialMttrMinutes.toString() : "",
+  );
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewResult, setPreviewResult] = useState<SLAResult | null>(null);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  async function handleResolve() {
+    const parsed = Number(mttrInput);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      setValidationError("MTTR must be a non-negative number.");
+      return;
+    }
+
+    setValidationError(null);
+    await onConfirmResolve(parsed);
+  }
+
+  async function handlePreview() {
+    const parsed = Number(mttrInput);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      setValidationError("MTTR must be a non-negative number.");
+      return;
+    }
+
+    setValidationError(null);
+    setPreviewError(null);
+    setIsPreviewLoading(true);
+
+    try {
+      const result = await previewSLA({
+        severity,
+        mttr_minutes: parsed,
+      });
+      setPreviewResult(result);
+    } catch (issue) {
+      setPreviewError(issue instanceof Error ? issue.message : "Failed to preview SLA.");
+    } finally {
+      setIsPreviewLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow-xl">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold text-slate-900">Resolve outage</h2>
+          <p className="text-sm text-slate-500">
+            Confirm the MTTR for <span className="font-medium text-slate-700">{siteName}</span> and
+            resolve outage <span className="font-medium text-slate-700">{outageId}</span>.
+          </p>
+        </div>
+
+        <div className="mt-6 space-y-4">
+          <div>
+            <label
+              htmlFor="resolve-outage-mttr"
+              className="mb-2 block text-sm font-medium text-slate-700"
+            >
+              Mean time to resolve (minutes)
+            </label>
+            <input
+              id="resolve-outage-mttr"
+              type="number"
+              min={0}
+              value={mttrInput}
+              onChange={(event) => {
+                setMttrInput(event.target.value);
+                setPreviewResult(null);
+                setPreviewError(null);
+              }}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+              placeholder="Enter MTTR in minutes"
+            />
+          </div>
+
+          {validationError ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+              {validationError}
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+
+          {previewError ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+              {previewError}
+            </div>
+          ) : null}
+
+          {previewResult ? (
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <h3 className="text-sm font-semibold text-slate-900">SLA outcome preview</h3>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-lg bg-white px-3 py-2">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">Status</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">
+                    {previewResult.status}
+                  </div>
+                </div>
+                <div className="rounded-lg bg-white px-3 py-2">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">Rating</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">
+                    {previewResult.rating}
+                  </div>
+                </div>
+                <div className="rounded-lg bg-white px-3 py-2">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">Threshold</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">
+                    {previewResult.threshold_minutes} min
+                  </div>
+                </div>
+                <div className="rounded-lg bg-white px-3 py-2">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">Payout</div>
+                  <div
+                    className={`mt-1 text-sm font-medium ${
+                      previewResult.amount >= 0 ? "text-emerald-600" : "text-red-600"
+                    }`}
+                  >
+                    {previewResult.amount >= 0 ? "+" : ""}
+                    {previewResult.amount} ({previewResult.payment_type})
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={isResolving}
+            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handlePreview}
+            disabled={isResolving || isPreviewLoading}
+            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+          >
+            {isPreviewLoading ? "Previewing..." : "Preview SLA"}
+          </button>
+          <button
+            onClick={handleResolve}
+            disabled={isResolving}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+          >
+            {isResolving ? "Resolving..." : "Confirm resolution"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
 [FE-024] Add dead-letter and replay review workflows for webhook deliveries



Description
The backend now supports dead-lettered deliveries and replay behavior, but the frontend does not expose a practical review loop for those operational states. This leaves a key observability and recovery feature inaccessible.

Acceptance Criteria
Dead-letter deliveries are visible as a distinct state in the webhooks UI
Operators can replay eligible deliveries or filtered groups with clear feedback and status refresh
Replay actions avoid stale UI and expose enough context to understand what was retried
closes #182