### PR TITLE
docs: add route-level ADR templates and baseline ADR entries [FE-W5-121]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,6 +427,25 @@ cargo test
 cargo test -- --nocapture
 ```
 
+## 🗺️ Architecture Decision Records (ADRs)
+
+Significant route-level decisions are tracked in [`docs/adr/`](./docs/adr/README.md).
+
+**When contributing to a critical route** (`/outages`, `/payments`, `/login`, `/register`, `/config`, `/setting`), check whether an ADR exists for the pattern you're changing. If your change alters the architecture of a route:
+
+1. Copy [`docs/adr/000-template.md`](./docs/adr/000-template.md) to a new numbered file
+2. Fill in all sections, including the route(s) affected
+3. Add a row to the [`docs/adr/README.md`](./docs/adr/README.md) index
+4. Reference the ADR number in your PR description
+
+**Existing ADRs by route:**
+
+| Route | ADR |
+|-------|-----|
+| `/login`, `/register` | [ADR-001: Auth Route Session Strategy](./docs/adr/001-auth-route-session-strategy.md) |
+| `/outages` | [ADR-002: Outages Route Data Fetching Strategy](./docs/adr/002-outages-route-data-fetching.md) |
+| `/payments` | [ADR-003: Payments Route Stellar Integration](./docs/adr/003-payments-route-stellar-integration.md) |
+
 ## 📚 Documentation Guidelines
 
 - Use **clear, concise language**

--- a/docs/adr/000-template.md
+++ b/docs/adr/000-template.md
@@ -1,0 +1,29 @@
+# ADR-[NUMBER]: [Title]
+
+**Date:** YYYY-MM-DD  
+**Status:** Proposed | Accepted | Deprecated | Superseded by [ADR-XXX]  
+**Route(s):** `/route-path`  
+**Deciders:** [team/contributors involved]
+
+## Context
+
+What is the issue motivating this decision? What forces are at play?
+
+## Decision
+
+What is the change being proposed or adopted?
+
+## Consequences
+
+What becomes easier or harder after this decision? Include trade-offs.
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|--------|----------------|
+|        |                |
+
+## References
+
+- Related issue: #
+- Related ADR: ADR-XXX

--- a/docs/adr/001-auth-route-session-strategy.md
+++ b/docs/adr/001-auth-route-session-strategy.md
@@ -1,0 +1,35 @@
+# ADR-001: Auth Route Session Strategy
+
+**Date:** 2026-06-24  
+**Status:** Accepted  
+**Route(s):** `/login`, `/register`, `/(auth)/logic`  
+**Deciders:** OpSoll frontend team
+
+## Context
+
+The auth routes (`/login`, `/register`) must handle token storage, redirect preservation, and session hydration consistently. An inconsistent strategy causes redirect loops and lost in-flight state after login.
+
+## Decision
+
+- Session state is managed via `SessionProvider` (`src/providers/session.tsx`) wrapping the app.
+- On login success, `redirect` query param is consumed and the user is sent to the preserved route.
+- Auth utilities live in `src/lib/auth/` and are shared across all auth routes.
+- `RouteGuard` (`src/components/RouteGuard.tsx`) enforces auth on protected routes.
+
+## Consequences
+
+- All auth logic is colocated; adding new auth providers only requires updating `src/lib/auth/`.
+- Redirect preservation is guaranteed but requires the login page to forward the `?redirect=` param.
+- Server components cannot access session directly — they rely on `RouteGuard` client-side checks.
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|--------|----------------|
+| Next.js middleware-based auth | Added complexity without benefit given current backend JWT model |
+| Cookie-only session | Freighter wallet auth is client-side, making server cookie approach impractical |
+
+## References
+
+- Related issue: #213
+- `src/lib/auth/`, `src/providers/session.tsx`, `src/components/RouteGuard.tsx`

--- a/docs/adr/002-outages-route-data-fetching.md
+++ b/docs/adr/002-outages-route-data-fetching.md
@@ -1,0 +1,33 @@
+# ADR-002: Outages Route Data Fetching Strategy
+
+**Date:** 2026-06-24  
+**Status:** Accepted  
+**Route(s):** `/outages`, `/outages/[id]`, `/outages/new`  
+**Deciders:** OpSoll frontend team
+
+## Context
+
+Outages are the core operational surface. The route must support list views, detail drill-down, new outage creation, and SLA dispute panels — each with different data freshness requirements.
+
+## Decision
+
+- List view (`/outages`) uses React Query with a short stale time for near-real-time refresh.
+- Detail view (`/outages/[id]`) fetches via `src/services/outages.ts` and passes data to page components.
+- New outage form is client-only; submission calls the outages service directly.
+- SLA dispute state is managed locally in `SLADisputesPanel` and synced via service calls.
+
+## Consequences
+
+- Consistent cache invalidation: creating/updating an outage invalidates the list query key.
+- Detail route is coupled to the outages service contract — changes to the API shape require service layer updates.
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|--------|----------------|
+| Server-side data fetching (RSC) | Outage state changes frequently; client-side polling is more appropriate |
+| SWR | React Query already in use across the app; no reason to add a second cache library |
+
+## References
+
+- `src/services/outages.ts`, `src/app/outages/`, `src/components/outages/SLADisputesPanel.tsx`

--- a/docs/adr/003-payments-route-stellar-integration.md
+++ b/docs/adr/003-payments-route-stellar-integration.md
@@ -1,0 +1,35 @@
+# ADR-003: Payments Route Stellar Integration
+
+**Date:** 2026-06-24  
+**Status:** Accepted  
+**Route(s):** `/payments`  
+**Deciders:** OpSoll frontend team
+
+## Context
+
+Payments are executed on the Stellar network. The payments route must present transaction history, allow dispute actions, and interact with the Freighter wallet — all without blocking the main UI thread.
+
+## Decision
+
+- Stellar network calls are wrapped in `src/services/paymentService.ts`; no direct SDK calls from components.
+- Freighter wallet interactions are handled via `src/lib/auth/` utilities.
+- Payment detail state is kept in a drawer (`payment-detail-drawer.tsx`) to avoid full-page navigations.
+- All monetary amounts are treated as strings to avoid floating-point precision issues.
+
+## Consequences
+
+- The service layer is the single integration point; swapping Stellar SDK versions requires changes only in `paymentService.ts`.
+- Drawer-based detail avoids losing list scroll position.
+- String-based amounts require explicit formatting before display.
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|--------|----------------|
+| Direct Stellar SDK calls in components | Couples UI to SDK; hard to test and mock |
+| Separate payments page for each transaction | Creates excessive routing overhead |
+
+## References
+
+- `src/services/paymentService.ts`, `src/app/payments/`, `src/components/payments/`
+- Related: `docs/STELLAR_INTEGRATION.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,27 @@
+# Architecture Decision Records
+
+This directory contains ADRs for significant frontend architectural decisions, scoped per route domain.
+
+## Index
+
+| ADR | Title | Route(s) | Status |
+|-----|-------|----------|--------|
+| [000](./000-template.md) | Template | — | Template |
+| [001](./001-auth-route-session-strategy.md) | Auth Route Session Strategy | `/login`, `/register` | Accepted |
+| [002](./002-outages-route-data-fetching.md) | Outages Route Data Fetching Strategy | `/outages`, `/outages/[id]` | Accepted |
+| [003](./003-payments-route-stellar-integration.md) | Payments Route Stellar Integration | `/payments` | Accepted |
+
+## When to Write an ADR
+
+Write an ADR when:
+- Choosing a data-fetching pattern for a new route
+- Changing how auth/session is propagated
+- Adopting a new library that affects multiple routes
+- Making a breaking change to a shared service contract
+
+## How to Add a New ADR
+
+1. Copy `000-template.md` to `NNN-short-title.md` (next number in sequence)
+2. Fill in all sections
+3. Add a row to the index above
+4. Link from the relevant route's section in `CONTRIBUTING.md`


### PR DESCRIPTION
## Description
Implements route-level ADR templates for major frontend decisions.

## Changes
- Add `docs/adr/` directory with `000-template.md` for contributor use
- Add baseline ADR entries for three critical routes:
  - ADR-001: Auth route session strategy (`/login`, `/register`)
  - ADR-002: Outages route data fetching (`/outages`, `/outages/[id]`)
  - ADR-003: Payments route Stellar integration (`/payments`)
- Add `docs/adr/README.md` index with route-to-ADR lookup table
- Link ADR directory from `CONTRIBUTING.md` with guidance on when to write an ADR

## Acceptance Criteria Met
- [x] ADR template integrated into contributor workflow (CONTRIBUTING.md + template file)
- [x] Critical routes have baseline ADR entries
- [x] ADR links are discoverable from CONTRIBUTING.md and the ADR index

Closes #292