### PR TITLE
docs: add CODEOWNERS and escalation map for high-risk modules [FE-W5-119]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,41 @@
+# CODEOWNERS
+# Each line maps a path pattern to one or more owner teams/users.
+# Owners are automatically requested for review when a PR modifies matching files.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: all files require review from the core team
+*                                   @OpSoll/noc-iq-frontend
+
+# ── High-Risk Modules ────────────────────────────────────────────────────────
+
+# Auth & session (session hijack, redirect bugs = critical)
+src/lib/auth/                       @OpSoll/noc-iq-frontend @OpSoll/noc-iq-security
+src/providers/session.tsx           @OpSoll/noc-iq-frontend @OpSoll/noc-iq-security
+src/components/RouteGuard.tsx       @OpSoll/noc-iq-frontend @OpSoll/noc-iq-security
+
+# Stellar / payment integrations (financial risk)
+src/services/paymentService.ts      @OpSoll/noc-iq-frontend @OpSoll/noc-iq-stellar
+src/lib/client.ts                   @OpSoll/noc-iq-frontend @OpSoll/noc-iq-stellar
+src/app/payments/                   @OpSoll/noc-iq-frontend @OpSoll/noc-iq-stellar
+src/components/payments/            @OpSoll/noc-iq-frontend @OpSoll/noc-iq-stellar
+
+# Outages core (operational impact)
+src/services/outages.ts             @OpSoll/noc-iq-frontend
+src/app/outages/                    @OpSoll/noc-iq-frontend
+src/components/outages/             @OpSoll/noc-iq-frontend
+
+# SLA logic (contract / billing impact)
+src/services/sla.ts                 @OpSoll/noc-iq-frontend @OpSoll/noc-iq-stellar
+src/hooks/useSlaConfig.ts           @OpSoll/noc-iq-frontend @OpSoll/noc-iq-stellar
+
+# API & environment config (affects all environments)
+src/lib/api.ts                      @OpSoll/noc-iq-frontend
+src/lib/config/                     @OpSoll/noc-iq-frontend
+src/app/config/                     @OpSoll/noc-iq-frontend
+
+# ── CI / Workflow ─────────────────────────────────────────────────────────────
+.github/                            @OpSoll/noc-iq-frontend
+
+# ── Documentation ─────────────────────────────────────────────────────────────
+docs/                               @OpSoll/noc-iq-frontend
+CONTRIBUTING.md                     @OpSoll/noc-iq-frontend

--- a/docs/ESCALATION.md
+++ b/docs/ESCALATION.md
@@ -1,0 +1,53 @@
+# Escalation Map
+
+On-call paths and owner contacts for high-risk frontend modules.
+
+## Module Ownership
+
+| Module / Path | Risk | Owner Group | Fallback |
+|---------------|------|-------------|---------|
+| `src/lib/auth/`, `src/providers/session.tsx`, `src/components/RouteGuard.tsx` | 🔴 Critical — auth/session | `@OpSoll/noc-iq-security` | `@OpSoll/noc-iq-frontend` |
+| `src/services/paymentService.ts`, `src/app/payments/`, `src/components/payments/` | 🔴 Critical — financial | `@OpSoll/noc-iq-stellar` | `@OpSoll/noc-iq-frontend` |
+| `src/services/sla.ts`, `src/hooks/useSlaConfig.ts` | 🔴 Critical — contract/billing | `@OpSoll/noc-iq-stellar` | `@OpSoll/noc-iq-frontend` |
+| `src/services/outages.ts`, `src/app/outages/` | 🟠 High — operational | `@OpSoll/noc-iq-frontend` | Any contributor assigned to FE issues |
+| `src/lib/api.ts`, `src/lib/config/`, `src/app/config/` | 🟠 High — env config | `@OpSoll/noc-iq-frontend` | Any contributor assigned to FE issues |
+| `.github/workflows/` | 🟡 Medium — CI | `@OpSoll/noc-iq-frontend` | Repository admin |
+
+## Escalation Paths
+
+### Incident Response (Production Issue)
+
+1. **P0 — Auth or Payment broken**
+   - Page `@OpSoll/noc-iq-security` + `@OpSoll/noc-iq-stellar` immediately via Discord `#incidents`
+   - If no response within 15 min → escalate to repository admin
+   - Rollback via: revert the relevant merge commit on `main` and force-deploy
+
+2. **P1 — Outage route unavailable**
+   - Ping `@OpSoll/noc-iq-frontend` in Discord `#incidents`
+   - If no response within 30 min → escalate to repository admin
+
+3. **P2 — Non-blocking UI regression**
+   - Open a GitHub issue tagged `bug`, `priority: high`
+   - Assign to owning team from the table above
+
+### Review Escalation (PR Stuck)
+
+If a PR touching a high-risk module has not received review within **48 hours**:
+1. Comment `@OpSoll/noc-iq-frontend` on the PR requesting review
+2. If still no response after 24 hours → ping in Discord `#fe-reviews`
+3. If blocked by an absent owner → repository admin may approve with a second contributor's sign-off
+
+## Machine-Readable Ownership
+
+Ownership is encoded in `.github/CODEOWNERS`. Tools can parse this file to:
+- Auto-assign reviewers (GitHub enforces this natively)
+- Generate ownership reports: `grep "^src/" .github/CODEOWNERS`
+- Feed into incident routing scripts
+
+## Communication Channels
+
+| Channel | Purpose |
+|---------|---------|
+| GitHub Issues | Bug reports, feature requests, escalation tracking |
+| Discord `#incidents` | Live incident coordination |
+| Discord `#fe-reviews` | PR review requests |


### PR DESCRIPTION
## Description
Defines code ownership and escalation guidance for high-risk frontend modules.

## Changes
- **`.github/CODEOWNERS`**: Maps high-risk paths (auth, payments/Stellar, SLA, outages, config, CI, docs) to owner groups with fallback contacts. GitHub enforces review requests automatically.
- **`docs/ESCALATION.md`**: Defines P0/P1/P2 incident response paths, PR review escalation steps, communication channels, and machine-readable ownership guidance.

## Acceptance Criteria Met
- [x] High-risk modules have explicit owner groups and fallback contacts (CODEOWNERS)
- [x] Ownership metadata is machine-readable for automation hooks (CODEOWNERS format)
- [x] Docs include escalation paths for on-call incidents (ESCALATION.md)

Closes #290