### PR TITLE
feat: add contributor contract-change checklist with auto hints [FE-W5-118]

### DIFF
--- a/.github/workflows/contract-change-check.yml
+++ b/.github/workflows/contract-change-check.yml
@@ -1,0 +1,51 @@
+name: Contract Change Checklist
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/services/**'
+      - 'src/lib/api.ts'
+      - 'src/lib/client.ts'
+      - 'src/lib/auth/**'
+      - 'src/hooks/useSlaConfig.ts'
+
+jobs:
+  contract-check:
+    name: Detect contract changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run contract-change check
+        run: node scripts/contract-change-check.mjs --base origin/main
+        # Exit 1 means contract changes found — post as PR comment, don't block hard
+        continue-on-error: true
+        id: check
+
+      - name: Post checklist comment
+        if: steps.check.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## ⚠️ Backend Contract Change Detected
+
+            This PR modifies service or API integration files. Please confirm the following before merging:
+
+            - [ ] Affected test files pass locally (\`npm test\`)
+            - [ ] \`docs/API.md\` updated if the API shape changed
+            - [ ] Relevant ADR in \`docs/adr/\` updated if the pattern changed
+            - [ ] Type definitions in \`src/types/\` match the new contract
+
+            Run \`node scripts/contract-change-check.mjs\` locally to see the full list of impacted services and routes.`
+            });

--- a/docs/CONTRACT_CHANGE_GUIDE.md
+++ b/docs/CONTRACT_CHANGE_GUIDE.md
@@ -1,0 +1,44 @@
+# Contract Change Guide
+
+When a backend API contract changes (new/removed fields, changed endpoints), this guide ensures frontend contributors update all impacted surfaces before merging.
+
+## Automatic Detection
+
+The CI workflow (`.github/workflows/contract-change-check.yml`) triggers on PRs that modify service files and posts a checklist comment automatically.
+
+To run locally before pushing:
+
+```bash
+node scripts/contract-change-check.mjs
+```
+
+Or against a specific base:
+
+```bash
+node scripts/contract-change-check.mjs --base origin/main
+```
+
+## What Counts as a Contract Change
+
+| File changed | Impacted service | Affected routes |
+|---|---|---|
+| `src/services/outages.ts`, `src/lib/api.ts` | outages | `/outages`, `/outages/[id]`, `/outages/new` |
+| `src/services/paymentService.ts`, `src/lib/client.ts` | payments | `/payments` |
+| `src/services/sla.ts`, `src/hooks/useSlaConfig.ts` | sla | `/outages/[id]`, `/config` |
+| `src/services/bulkImportService.ts` | bulkImport | `/bulk-import`, `/bulk-import/history` |
+| `src/services/webhookService.ts` | webhooks | `/webhooks` |
+| `src/lib/auth/**` | auth | `/login`, `/register` |
+
+## Checklist
+
+When the script or CI flags a contract change, confirm:
+
+- [ ] Run the affected test files and confirm they pass
+- [ ] Update `docs/API.md` if the API response shape changed
+- [ ] Update the relevant ADR in `docs/adr/` if the architectural pattern changed
+- [ ] Update type definitions in `src/types/` to match the new contract
+- [ ] If a new field is optional for now, add a `// TODO:` with the migration plan
+
+## Adding New Services
+
+To track a new service in the checker, add an entry to the `CONTRACT_MAP` array in `scripts/contract-change-check.mjs` and add the file pattern to the `paths` filter in `.github/workflows/contract-change-check.yml`.

--- a/scripts/contract-change-check.mjs
+++ b/scripts/contract-change-check.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * contract-change-check.mjs
+ *
+ * Detects impacted services and routes from changed files and prints
+ * a contributor checklist when backend contracts may have changed.
+ *
+ * Usage:
+ *   node scripts/contract-change-check.mjs [--base <ref>]
+ *
+ * Exits 0 if no contract changes detected, 1 if checklist items are printed.
+ */
+
+import { execSync } from "child_process";
+
+const BASE = process.argv.includes("--base")
+  ? process.argv[process.argv.indexOf("--base") + 1]
+  : "origin/main";
+
+// Map of file patterns to the service/route they affect
+const CONTRACT_MAP = [
+  {
+    pattern: /src\/services\/outages\.ts|src\/lib\/api\.ts/,
+    service: "outages",
+    routes: ["/outages", "/outages/[id]", "/outages/new"],
+    tests: ["tests/outages-flow.test.tsx"],
+    docs: ["docs/API.md", "docs/adr/002-outages-route-data-fetching.md"],
+  },
+  {
+    pattern: /src\/services\/paymentService\.ts|src\/lib\/client\.ts/,
+    service: "payments",
+    routes: ["/payments"],
+    tests: ["tests/payments-view.test.tsx"],
+    docs: ["docs/API.md", "docs/adr/003-payments-route-stellar-integration.md"],
+  },
+  {
+    pattern: /src\/services\/sla\.ts|src\/hooks\/useSlaConfig\.ts/,
+    service: "sla",
+    routes: ["/outages/[id]", "/config"],
+    tests: ["src/hooks/useSlaConfig.test.tsx"],
+    docs: ["docs/API.md"],
+  },
+  {
+    pattern: /src\/services\/bulkImportService\.ts/,
+    service: "bulkImport",
+    routes: ["/bulk-import", "/bulk-import/history"],
+    tests: ["tests/bulk-import-view.test.tsx"],
+    docs: ["docs/API.md"],
+  },
+  {
+    pattern: /src\/services\/webhookService\.ts/,
+    service: "webhooks",
+    routes: ["/webhooks"],
+    tests: [],
+    docs: ["docs/API.md"],
+  },
+  {
+    pattern: /src\/lib\/auth\//,
+    service: "auth",
+    routes: ["/login", "/register"],
+    tests: ["tests/auth-flow.test.tsx"],
+    docs: ["docs/adr/001-auth-route-session-strategy.md"],
+  },
+];
+
+function getChangedFiles() {
+  try {
+    const output = execSync(`git diff --name-only ${BASE} HEAD`, {
+      encoding: "utf8",
+    });
+    return output.trim().split("\n").filter(Boolean);
+  } catch {
+    // Fallback: staged files
+    const output = execSync("git diff --name-only --cached", {
+      encoding: "utf8",
+    });
+    return output.trim().split("\n").filter(Boolean);
+  }
+}
+
+const changed = getChangedFiles();
+if (!changed.length) {
+  console.log("✅ No changed files detected.");
+  process.exit(0);
+}
+
+const impacted = CONTRACT_MAP.filter(({ pattern }) =>
+  changed.some((f) => pattern.test(f))
+);
+
+if (!impacted.length) {
+  console.log("✅ No backend contract changes detected.");
+  process.exit(0);
+}
+
+console.log("\n⚠️  Backend contract changes detected!\n");
+console.log("Impacted services and routes:\n");
+
+impacted.forEach(({ service, routes, tests, docs }) => {
+  console.log(`  Service: ${service}`);
+  console.log(`  Routes:  ${routes.join(", ")}`);
+  if (tests.length) console.log(`  Tests:   ${tests.join(", ")}`);
+  if (docs.length) console.log(`  Docs:    ${docs.join(", ")}`);
+  console.log("");
+});
+
+console.log("📋 Contributor Checklist:");
+console.log(
+  "  [ ] Run the affected test files listed above and confirm they pass"
+);
+console.log("  [ ] Update docs/API.md if the API shape changed");
+console.log("  [ ] Update the relevant ADR in docs/adr/ if the pattern changed");
+console.log(
+  "  [ ] Update type definitions in src/types/ to match new contract"
+);
+console.log(
+  "  [ ] If a new field is optional for now, add a TODO with the migration plan"
+);
+console.log("");
+console.log(
+  "Fix the checklist items above before merging. This check exits with code 1."
+);
+process.exit(1);


### PR DESCRIPTION
## Description
Guides contributors through frontend steps required when backend contracts change.

## Changes
- **`scripts/contract-change-check.mjs`**: Node script that diffs changed files against `origin/main`, matches them to the service/route contract map, and prints a contributor checklist with tests and docs to update. Exits 1 when contract changes are detected.
- **`.github/workflows/contract-change-check.yml`**: CI workflow that runs on PRs touching `src/services/**`, `src/lib/api.ts`, `src/lib/auth/**`, etc. Posts a checklist comment on the PR when changes are detected.
- **`docs/CONTRACT_CHANGE_GUIDE.md`**: Documents the workflow, the contract map table, the checklist, and how to extend it for new services.

## Acceptance Criteria Met
- [x] Checklist auto-detects impacted services/routes from changed files
- [x] Hints include tests and docs to update
- [x] Checklist runs in CI (workflow) and can be run locally (`node scripts/contract-change-check.mjs`)

Closes #289