### PR TITLE
feat: invalidation registry, request coalescing, retry policy, cache hydration

### DIFF
--- a/src/lib/cacheHydration.test.ts
+++ b/src/lib/cacheHydration.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { hydrateCache, createHydrationBoundary } from "./cacheHydration";
+
+describe("hydrateCache", () => {
+  it("sets initial data in cache", () => {
+    const client = new QueryClient();
+    hydrateCache(client, { dashboard: { total: 10 } });
+    expect(client.getQueryData(["dashboard"])).toEqual({ total: 10 });
+  });
+});
+
+describe("createHydrationBoundary", () => {
+  it("tracks hydration state", () => {
+    const client = new QueryClient();
+    const boundary = createHydrationBoundary(client);
+    expect(boundary.isHydrated("test")).toBe(false);
+    boundary.markHydrated("test");
+    expect(boundary.isHydrated("test")).toBe(true);
+  });
+  it("skips fetch if already hydrated", async () => {
+    const client = new QueryClient();
+    const boundary = createHydrationBoundary(client);
+    client.setQueryData(["key"], "cached");
+    boundary.markHydrated("key");
+    const result = await boundary.prefetchWithHydration("key", async () => "fresh");
+    expect(result).toBe("cached");
+  });
+});

--- a/src/lib/cacheHydration.ts
+++ b/src/lib/cacheHydration.ts
@@ -1,0 +1,22 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function hydrateCache(queryClient: QueryClient, initialState: Record<string, unknown>): void {
+  for (const [key, data] of Object.entries(initialState)) {
+    queryClient.setQueryData([key], data);
+  }
+}
+
+export function createHydrationBoundary(queryClient: QueryClient) {
+  const hydrated = new Set<string>();
+  return {
+    isHydrated(key: string): boolean { return hydrated.has(key); },
+    markHydrated(key: string): void { hydrated.add(key); },
+    async prefetchWithHydration<T>(key: string, fetcher: () => Promise<T>): Promise<T | undefined> {
+      if (hydrated.has(key)) return queryClient.getQueryData<T>([key]);
+      const data = await fetcher();
+      queryClient.setQueryData([key], data);
+      hydrated.add(key);
+      return data;
+    },
+  };
+}

--- a/src/lib/invalidation.test.ts
+++ b/src/lib/invalidation.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { getInvalidations, invalidationMap } from "./invalidation";
+
+describe("getInvalidations", () => {
+  it("returns keys for known mutations", () => {
+    expect(getInvalidations("outage.create").length).toBeGreaterThan(0);
+    expect(getInvalidations("payment.process").length).toBeGreaterThan(0);
+  });
+  it("returns empty for unknown mutations", () => {
+    expect(getInvalidations("unknown.mutation")).toEqual([]);
+  });
+});
+
+describe("invalidationMap", () => {
+  it("has entries for all major entities", () => {
+    const types = invalidationMap.map((e) => e.mutationType);
+    expect(types).toContain("outage.create");
+    expect(types).toContain("payment.process");
+    expect(types).toContain("webhook.create");
+  });
+  it("no full-cache blast patterns", () => {
+    for (const entry of invalidationMap) {
+      for (const key of entry.invalidate) {
+        expect(key).not.toEqual(["*"]);
+      }
+    }
+  });
+});

--- a/src/lib/invalidation.ts
+++ b/src/lib/invalidation.ts
@@ -1,0 +1,32 @@
+import { QueryClient } from "@tanstack/react-query";
+
+type QueryKeyPattern = (string | Record<string, unknown>)[];
+
+interface InvalidationEntry {
+  mutationType: string;
+  invalidate: QueryKeyPattern[];
+}
+
+const invalidationMap: InvalidationEntry[] = [
+  { mutationType: "outage.create", invalidate: [["outages"], ["dashboard-metrics"]] },
+  { mutationType: "outage.update", invalidate: [["outages"], ["dashboard-metrics"]] },
+  { mutationType: "outage.resolve", invalidate: [["outages"], ["dashboard-metrics"], ["sla"]] },
+  { mutationType: "outage.delete", invalidate: [["outages"], ["dashboard-metrics"]] },
+  { mutationType: "payment.process", invalidate: [["payments"], ["dashboard-metrics"]] },
+  { mutationType: "payment.refund", invalidate: [["payments"], ["dashboard-metrics"]] },
+  { mutationType: "webhook.create", invalidate: [["webhooks"]] },
+  { mutationType: "webhook.update", invalidate: [["webhooks"]] },
+  { mutationType: "webhook.delete", invalidate: [["webhooks"]] },
+  { mutationType: "sla.update", invalidate: [["sla"], ["dashboard-metrics"]] },
+];
+
+export function getInvalidations(mutationType: string): QueryKeyPattern[] {
+  return invalidationMap.find((e) => e.mutationType === mutationType)?.invalidate ?? [];
+}
+
+export async function invalidateForMutation(queryClient: QueryClient, mutationType: string): Promise<void> {
+  const keys = getInvalidations(mutationType);
+  await Promise.all(keys.map((k) => queryClient.invalidateQueries({ queryKey: k as readonly unknown[] })));
+}
+
+export { invalidationMap };

--- a/src/lib/requestCoalesce.test.ts
+++ b/src/lib/requestCoalesce.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { createCoalescer } from "./requestCoalesce";
+
+describe("requestCoalesce", () => {
+  it("deduplicates identical requests", async () => {
+    const coalescer = createCoalescer();
+    const fetcher = vi.fn().mockResolvedValue("data");
+    const [a, b] = await Promise.all([
+      coalescer.request("key1", fetcher),
+      coalescer.request("key1", fetcher),
+    ]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(a).toBe("data");
+    expect(b).toBe("data");
+  });
+
+  it("isolates by auth scope", async () => {
+    const coalescer = createCoalescer();
+    const f1 = vi.fn().mockResolvedValue("a");
+    const f2 = vi.fn().mockResolvedValue("b");
+    await Promise.all([
+      coalescer.request("key", f1, { authScope: "user1" }),
+      coalescer.request("key", f2, { authScope: "user2" }),
+    ]);
+    expect(f1).toHaveBeenCalledTimes(1);
+    expect(f2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/requestCoalesce.ts
+++ b/src/lib/requestCoalesce.ts
@@ -1,0 +1,29 @@
+type Fetcher<T> = () => Promise<T>;
+
+interface InFlightRequest<T> {
+  promise: Promise<T>;
+  refCount: number;
+}
+
+export function createCoalescer() {
+  const inflight = new Map<string, InFlightRequest<unknown>>();
+
+  async function request<T>(key: string, fetcher: Fetcher<T>, options?: { authScope?: string }): Promise<T> {
+    const fullKey = options?.authScope ? `${key}:${options.authScope}` : key;
+    const existing = inflight.get(fullKey);
+    if (existing) {
+      existing.refCount++;
+      return existing.promise as Promise<T>;
+    }
+    const promise = fetcher().finally(() => {
+      const entry = inflight.get(fullKey);
+      if (entry && --entry.refCount <= 0) inflight.delete(fullKey);
+    });
+    inflight.set(fullKey, { promise, refCount: 1 });
+    return promise;
+  }
+
+  function clear(): void { inflight.clear(); }
+  function getInflightCount(): number { return inflight.size; }
+  return { request, clear, getInflightCount };
+}

--- a/src/lib/retryPolicy.test.ts
+++ b/src/lib/retryPolicy.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { getRetryConfig, classifyError } from "./retryPolicy";
+
+describe("getRetryConfig", () => {
+  it("returns correct config for timeout", () => {
+    expect(getRetryConfig("timeout").maxRetries).toBe(3);
+  });
+  it("returns no retries for auth", () => {
+    expect(getRetryConfig("auth").maxRetries).toBe(0);
+  });
+});
+
+describe("classifyError", () => {
+  it("classifies 401 as auth", () => { expect(classifyError(401)).toBe("auth"); });
+  it("classifies 500 as serverError", () => { expect(classifyError(500)).toBe("serverError"); });
+  it("classifies 422 as validation", () => { expect(classifyError(422)).toBe("validation"); });
+  it("classifies no status as network", () => { expect(classifyError()).toBe("network"); });
+  it("classifies timeout code", () => { expect(classifyError(undefined, "ECONNABORTED")).toBe("timeout"); });
+});

--- a/src/lib/retryPolicy.ts
+++ b/src/lib/retryPolicy.ts
@@ -1,0 +1,28 @@
+export type ErrorClass = "timeout" | "serverError" | "auth" | "validation" | "network";
+
+export interface RetryConfig {
+  maxRetries: number;
+  baseDelayMs: number;
+  backoffMultiplier: number;
+}
+
+const policies: Record<ErrorClass, RetryConfig> = {
+  timeout: { maxRetries: 3, baseDelayMs: 1000, backoffMultiplier: 2 },
+  serverError: { maxRetries: 3, baseDelayMs: 2000, backoffMultiplier: 2 },
+  auth: { maxRetries: 0, baseDelayMs: 0, backoffMultiplier: 1 },
+  validation: { maxRetries: 0, baseDelayMs: 0, backoffMultiplier: 1 },
+  network: { maxRetries: 2, baseDelayMs: 1000, backoffMultiplier: 2 },
+};
+
+export function getRetryConfig(errorClass: ErrorClass): RetryConfig {
+  return policies[errorClass] ?? policies.network;
+}
+
+export function classifyError(status?: number, code?: string): ErrorClass {
+  if (!status && code === "ECONNABORTED") return "timeout";
+  if (!status) return "network";
+  if (status === 401 || status === 403) return "auth";
+  if (status === 422) return "validation";
+  if (status >= 500) return "serverError";
+  return "network";
+}


### PR DESCRIPTION
Closes #232
Closes #233
Closes #234
Closes #235

Adds centralized mutation invalidation, request coalescing, deterministic retry policies, and cache hydration boundaries.