### PR TITLE
Outages: severity/status badges + Payments: date validation & clear filters

### DIFF
--- a/src/app/outages/components/outages-page-client.tsx
+++ b/src/app/outages/components/outages-page-client.tsx
@@ -6,12 +6,20 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { useToast } from "@/components/ui/toast";
 import { downloadCsv } from "@/lib/urlSyncAndExport";
 import { deleteOutage } from "@/services/outages";
+import { SeverityBadge } from "@/components/shared/SeverityBadgeAndShortcuts";
+import type { Severity, OutageStatus } from "@/types/outages";
 
 type Outage = {
   id: string;
   title: string;
-  status: string;
+  severity: Severity;
+  status: OutageStatus;
   createdAt: string;
+};
+
+const STATUS_STYLE: Record<OutageStatus, string> = {
+  open: "bg-amber-100 text-amber-800",
+  resolved: "bg-emerald-100 text-emerald-800",
 };
 
 type Props = {
@@ -183,6 +191,7 @@ export default function OutagesPageClient({
         filteredData.map((item) => ({
           ID: item.id,
           Title: item.title,
+          Severity: item.severity,
           Status: item.status,
           "Created At": new Date(item.createdAt).toISOString(),
         })),
@@ -288,8 +297,14 @@ export default function OutagesPageClient({
                   }
                 }}
               >
-                <div>
-                  <h3 className="font-medium">{item.title}</h3>
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <h3 className="font-medium">{item.title}</h3>
+                    <SeverityBadge severity={item.severity} />
+                    <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium uppercase ${STATUS_STYLE[item.status]}`}>
+                      {item.status}
+                    </span>
+                  </div>
                   <p className="text-sm text-muted-foreground">
                     {new Date(item.createdAt).toLocaleString()}
                   </p>

--- a/src/components/payments/payments-view.tsx
+++ b/src/components/payments/payments-view.tsx
@@ -6,35 +6,58 @@ import type { Payment } from "@/types/payment";
 import { useQuery } from "@tanstack/react-query";
 import { PaymentDetailDrawer } from "./payment-detail-drawer";
 
-import { queryKeys } from "@/lib/queryKeys";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationPrevious,
-  PaginationNext,
-  PaginationEllipsis,
-} from "@/components/ui/pagination";
 import {
   explorerLink,
   STELLAR_NETWORK_LABEL,
   type ExplorerEntityType,
 } from "@/lib/explorer";
-import { ExternalLink } from "lucide-react";
-
-import { Inbox } from "lucide-react";
+import { ExternalLink, Inbox } from "lucide-react";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
   Pagination,
   PaginationContent,
-  PaginationEllipsis,
   PaginationItem,
   PaginationLink,
-  PaginationNext,
   PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
 } from "@/components/ui/pagination";
 
+
+type SortDirection = "asc" | "desc";
+
+function SortableHeader({
+  columnKey,
+  label,
+  activeKey,
+  activeDir,
+  onSort,
+}: {
+  columnKey: string;
+  label: string;
+  activeKey: string;
+  activeDir: string;
+  onSort: (key: string) => void;
+}) {
+  const isActive = activeKey === columnKey;
+  return (
+    <th
+      className="cursor-pointer px-4 py-3 select-none"
+      onClick={() => onSort(columnKey)}
+      role="columnheader"
+      aria-sort={
+        isActive ? (activeDir === "asc" ? "ascending" : "descending") : "none"
+      }
+    >
+      {label}
+      {isActive && (
+        <span className="ml-1 text-xs" aria-hidden>
+          {activeDir === "asc" ? "\u25B2" : "\u25BC"}
+        </span>
+      )}
+    </th>
+  );
+}
 
 const URL_DEFAULTS = {
   status: "all",
@@ -107,19 +130,18 @@ export function PaymentsView() {
   const sortDir = urlState.sortDir as SortDirection;
   const selectedPaymentId = urlState.paymentId || null;
 
+  const dateError =
+    dateFrom && dateTo && dateFrom > dateTo
+      ? "Start date cannot be after end date."
+      : null;
+
+  const hasActiveFilters =
+    statusFilter !== URL_DEFAULTS.status ||
+    typeFilter !== URL_DEFAULTS.type ||
+    dateFrom !== URL_DEFAULTS.dateFrom ||
+    dateTo !== URL_DEFAULTS.dateTo;
+
   const { data, isLoading, error } = useQuery({
-
-    queryKey: queryKeys.payments.list({
-      statusFilter,
-      typeFilter,
-      dateFrom,
-      dateTo,
-      page,
-      perPage,
-      sortKey,
-      sortDir,
-    }),
-
     queryKey: [
       "payments",
       {
@@ -133,7 +155,6 @@ export function PaymentsView() {
         sortDir,
       },
     ],
-
     queryFn: () =>
       PaymentService.fetchPayments({
         status: statusFilter !== "all" ? statusFilter : undefined,
@@ -145,6 +166,7 @@ export function PaymentsView() {
         sort_by: sortKey,
         sort_dir: sortDir,
       }),
+    enabled: !dateError,
   });
 
   const payments = data?.items ?? [];
@@ -152,11 +174,7 @@ export function PaymentsView() {
   const totalPages = Math.ceil(total / perPage);
 
   const handleFilterChange = (key: string, value: string) => {
-
     setUrlState({ [key]: value, page: "1" } as Partial<typeof URL_DEFAULTS>);
-
-    setUrlState({ [key]: value, page: "1" } as any);
-
   };
 
   const handlePageChange = (newPage: number) => {
@@ -197,45 +215,63 @@ export function PaymentsView() {
             {STELLAR_NETWORK_LABEL}
           </span>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <select
-            value={statusFilter}
-            onChange={(e) => handleFilterChange("status", e.target.value)}
-            className="rounded border px-3 py-1.5 text-sm"
-            aria-label="Filter by status"
-          >
-            <option value="all">All Statuses</option>
-            <option value="PENDING">Pending</option>
-            <option value="CONFIRMED">Confirmed</option>
-            <option value="RELEASED">Released</option>
-            <option value="REFUNDED">Refunded</option>
-            <option value="FAILED">Failed</option>
-          </select>
-          <select
-            value={typeFilter}
-            onChange={(e) => handleFilterChange("type", e.target.value)}
-            className="rounded border px-3 py-1.5 text-sm"
-            aria-label="Filter by type"
-          >
-            <option value="all">All Types</option>
-            <option value="reward">Reward</option>
-            <option value="penalty">Penalty</option>
-            <option value="manual">Manual</option>
-          </select>
-          <input
-            type="date"
-            value={dateFrom}
-            onChange={(e) => handleFilterChange("dateFrom", e.target.value)}
-            className="rounded border px-3 py-1.5 text-sm"
-            aria-label="Date from"
-          />
-          <input
-            type="date"
-            value={dateTo}
-            onChange={(e) => handleFilterChange("dateTo", e.target.value)}
-            className="rounded border px-3 py-1.5 text-sm"
-            aria-label="Date to"
-          />
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={statusFilter}
+              onChange={(e) => handleFilterChange("status", e.target.value)}
+              className="rounded border px-3 py-1.5 text-sm"
+              aria-label="Filter by status"
+            >
+              <option value="all">All Statuses</option>
+              <option value="PENDING">Pending</option>
+              <option value="CONFIRMED">Confirmed</option>
+              <option value="RELEASED">Released</option>
+              <option value="REFUNDED">Refunded</option>
+              <option value="FAILED">Failed</option>
+            </select>
+            <select
+              value={typeFilter}
+              onChange={(e) => handleFilterChange("type", e.target.value)}
+              className="rounded border px-3 py-1.5 text-sm"
+              aria-label="Filter by type"
+            >
+              <option value="all">All Types</option>
+              <option value="reward">Reward</option>
+              <option value="penalty">Penalty</option>
+              <option value="manual">Manual</option>
+            </select>
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => handleFilterChange("dateFrom", e.target.value)}
+              className={`rounded border px-3 py-1.5 text-sm ${dateError ? "border-red-500" : ""}`}
+              aria-label="Date from"
+              aria-invalid={!!dateError}
+            />
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(e) => handleFilterChange("dateTo", e.target.value)}
+              className={`rounded border px-3 py-1.5 text-sm ${dateError ? "border-red-500" : ""}`}
+              aria-label="Date to"
+              aria-invalid={!!dateError}
+            />
+            {hasActiveFilters && (
+              <button
+                onClick={() => setUrlState(URL_DEFAULTS)}
+                className="rounded border px-3 py-1.5 text-sm hover:bg-gray-50"
+                aria-label="Clear all filters"
+              >
+                Clear Filters
+              </button>
+            )}
+          </div>
+          {dateError && (
+            <p className="text-sm text-red-600" role="alert">
+              {dateError}
+            </p>
+          )}
         </div>
       </div>
 
@@ -280,11 +316,7 @@ export function PaymentsView() {
               ))
             ) : payments.length === 0 ? (
               <tr>
-
-                <td colSpan={6} className="px-4 py-8 text-center text-gray-500">
-                  No payments found.
-
-                <td colSpan={5} className="px-4 py-8">
+                <td colSpan={6} className="px-4 py-8">
                   <EmptyState
                     icon={Inbox}
                     title="No payments found"
@@ -315,7 +347,6 @@ export function PaymentsView() {
                         : undefined
                     }
                   />
-
                 </td>
               </tr>
             ) : (

--- a/tests/payments-view.test.tsx
+++ b/tests/payments-view.test.tsx
@@ -57,6 +57,119 @@ describe("payment normalization", () => {
   });
 });
 
+describe("date validation logic", () => {
+  it("detects invalid date range when dateFrom is after dateTo", () => {
+    const dateFrom = "2026-07-30";
+    const dateTo = "2026-07-29";
+    const dateError =
+      dateFrom && dateTo && dateFrom > dateTo
+        ? "Start date cannot be after end date."
+        : null;
+    expect(dateError).toBe("Start date cannot be after end date.");
+  });
+
+  it("allows valid date range when dateFrom is before dateTo", () => {
+    const dateFrom = "2026-07-29";
+    const dateTo = "2026-07-30";
+    const dateError =
+      dateFrom && dateTo && dateFrom > dateTo
+        ? "Start date cannot be after end date."
+        : null;
+    expect(dateError).toBeNull();
+  });
+
+  it("allows valid date range when dateFrom equals dateTo", () => {
+    const dateFrom = "2026-07-30";
+    const dateTo = "2026-07-30";
+    const dateError =
+      dateFrom && dateTo && dateFrom > dateTo
+        ? "Start date cannot be after end date."
+        : null;
+    expect(dateError).toBeNull();
+  });
+
+  it("returns null when dateFrom is empty", () => {
+    const dateFrom = "";
+    const dateTo = "2026-07-30";
+    const dateError =
+      dateFrom && dateTo && dateFrom > dateTo
+        ? "Start date cannot be after end date."
+        : null;
+    expect(dateError).toBeNull();
+  });
+
+  it("returns null when dateTo is empty", () => {
+    const dateFrom = "2026-07-30";
+    const dateTo = "";
+    const dateError =
+      dateFrom && dateTo && dateFrom > dateTo
+        ? "Start date cannot be after end date."
+        : null;
+    expect(dateError).toBeNull();
+  });
+});
+
+describe("filter state reset", () => {
+  const URL_DEFAULTS = {
+    status: "all",
+    type: "all",
+    dateFrom: "",
+    dateTo: "",
+    page: "1",
+    perPage: "20",
+    paymentId: "",
+    sortKey: "created_at",
+    sortDir: "desc",
+  };
+
+  it("detects active filters", () => {
+    const state = { ...URL_DEFAULTS, status: "CONFIRMED" };
+    const hasActiveFilters =
+      state.status !== URL_DEFAULTS.status ||
+      state.type !== URL_DEFAULTS.type ||
+      state.dateFrom !== URL_DEFAULTS.dateFrom ||
+      state.dateTo !== URL_DEFAULTS.dateTo;
+    expect(hasActiveFilters).toBe(true);
+  });
+
+  it("detects no active filters when using defaults", () => {
+    const state = { ...URL_DEFAULTS };
+    const hasActiveFilters =
+      state.status !== URL_DEFAULTS.status ||
+      state.type !== URL_DEFAULTS.type ||
+      state.dateFrom !== URL_DEFAULTS.dateFrom ||
+      state.dateTo !== URL_DEFAULTS.dateTo;
+    expect(hasActiveFilters).toBe(false);
+  });
+
+  it("detects active filters with date range", () => {
+    const state = { ...URL_DEFAULTS, dateFrom: "2026-07-01", dateTo: "2026-07-30" };
+    const hasActiveFilters =
+      state.status !== URL_DEFAULTS.status ||
+      state.type !== URL_DEFAULTS.type ||
+      state.dateFrom !== URL_DEFAULTS.dateFrom ||
+      state.dateTo !== URL_DEFAULTS.dateTo;
+    expect(hasActiveFilters).toBe(true);
+  });
+
+  it("resets all parameters to defaults on clear", () => {
+    const dirtyState = {
+      status: "CONFIRMED",
+      type: "penalty",
+      dateFrom: "2026-07-01",
+      dateTo: "2026-07-30",
+      page: "3",
+      perPage: "50",
+      paymentId: "pay_123",
+      sortKey: "amount",
+      sortDir: "asc",
+    };
+    const resetState = { ...URL_DEFAULTS };
+    expect(resetState).toEqual(URL_DEFAULTS);
+    expect(dirtyState).not.toEqual(URL_DEFAULTS);
+  });
+});
+
 describe("payment history normalization", () => {
   it("preserves status transitions and audit metadata", () => {
     const entry = normalizePaymentHistoryEntry(


### PR DESCRIPTION
## Changes

### Issue #408 - Outages: Severity and status badges on row cards
- Updated local Outage type to include `severity` field using canonical types
- Imported and rendered `SeverityBadge` component on each row card
- Added color-coded status pills (open/resolved) with distinct background colors
- Layout remains responsive with flex-wrap

### Issue #404 - Payments: Date validation & clear filters
- Added inline date validation that displays error when `dateFrom > dateTo`
- Disabled API fetch when date-range is invalid via `enabled: !dateError`
- Added "Clear filters" button visible whenever any filter differs from defaults
- Clicking "Clear filters" resets all URL state parameters to defaults
- Also fixed: duplicate pagination imports, duplicate setUrlState call, broken empty-state JSX, missing SortableHeader component and SortDirection type
- Added unit tests for filter state reset and date validation logic

Closes #408
Closes #404